### PR TITLE
Add a native plugin-API to OBody.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,7 +3,7 @@ charset = utf-8
 insert_final_newline = true
 
 [*.{h,cmake,cpp}]
-indent_style = tab
+indent_style = space
 indent_size = 4
 
 [*.json]

--- a/cmakelists.txt
+++ b/cmakelists.txt
@@ -22,6 +22,7 @@ configure_file(
         @ONLY)
 
 set(sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/API/PluginInterface.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Body/Body.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Body/Event.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Papyrus/Papyrus.cpp

--- a/cmakelists.txt
+++ b/cmakelists.txt
@@ -22,6 +22,7 @@ configure_file(
         @ONLY)
 
 set(sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/ActorTracker/ActorTracker.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/API/PluginInterface.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Body/Body.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Body/Event.cpp

--- a/cmakelists.txt
+++ b/cmakelists.txt
@@ -49,6 +49,7 @@ find_package(CommonLibSSE CONFIG REQUIRED)
 find_package(ryml CONFIG REQUIRED)
 find_package(boost_algorithm CONFIG REQUIRED)
 find_package(boost_stl_interfaces CONFIG REQUIRED)
+find_package(boost_unordered CONFIG REQUIRED)
 
 add_commonlibsse_plugin(${PROJECT_NAME} SOURCES ${sources} AUTHOR ${PROJECT_AUTHOR})
 add_library("${PROJECT_NAME}::${PROJECT_NAME}" ALIAS "${PROJECT_NAME}")
@@ -71,7 +72,8 @@ target_link_libraries(
         pugixml
         rapidjson
         Boost::algorithm
-        Boost::stl_interfaces)
+        Boost::stl_interfaces
+        Boost::unordered)
 
 target_precompile_headers(
         ${PROJECT_NAME}

--- a/cmakelists.txt
+++ b/cmakelists.txt
@@ -30,6 +30,7 @@ set(sources
         ${CMAKE_CURRENT_SOURCE_DIR}/src/Papyrus/PapyrusBody.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/JSONParser/JSONParser.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/PresetManager/PresetManager.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/SaveFileState/SaveFileState.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp
 
         ${CMAKE_CURRENT_BINARY_DIR}/version.rc)

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -233,6 +233,11 @@ namespace OBody {
                 `ApplyOBodyMorphsToActor` can be used to reverse this operation.
                 Any per-actor configuration, such as the applied preset, will be retained for the actor. */
             virtual void RemoveOBodyMorphsFromActor(Actor* actor) = 0;
+
+            /** This is used to forcefully change whether ORefit is applied or not to an actor,
+                regardless of the actor's equipped armour, and without respect to the global setting
+                for ORefit. */
+            virtual void ForcefullyChangeORefitForActor(Actor* actor, bool orefitShouldBeApplied) = 0;
         };
 
         /** This is an interface for receiving events from OBody regarding

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -91,6 +91,7 @@ namespace OBody {
         class IActorChangeEventListener;
         struct PresetCounts;
         enum PresetCategory : uint64_t;
+        struct PresetAssignmentInformation;
 
         /** See the documentation for `IPluginInterface`, this is its base class purely to make it
             easier to maintain ABI-compatibility.
@@ -238,6 +239,10 @@ namespace OBody {
                 regardless of the actor's equipped armour, and without respect to the global setting
                 for ORefit. */
             virtual void ForcefullyChangeORefitForActor(Actor* actor, bool orefitShouldBeApplied) = 0;
+
+            /** This is used to get information about the preset currently assigned to an actor.
+                You MUST initialise the `flags` field of `payload`, every other field may be left uninitialised. */
+            virtual void GetPresetAssignedToActor(Actor* actor, PresetAssignmentInformation& payload) = 0;
         };
 
         /** This is an interface for receiving events from OBody regarding
@@ -330,6 +335,26 @@ namespace OBody {
             PresetCategoryMale = 1 << 2,
             /** Specifies blacklisted presets applicable to male actors. */
             PresetCategoryMaleBlacklisted = 1 << 3
+        };
+
+        struct PresetAssignmentInformation {
+            enum Flags : uint64_t {
+                None = 0,
+                /** This bit is set if the actor is female. */
+                IsFemale = 1 << 0
+            };
+
+            /** A bitwise combination of flags regarding the preset assignment. */
+            Flags flags = Flags::None;
+
+            /** This is the name of a preset assigned to an actor;
+                if no preset is assigned to the actor this will be an empty string.
+
+                This is a `string_view`, but the string it points to is null-terminated,
+                so it can be used as C-style string.
+                The data that this `string_view` points to is guaranteed to be valid
+                until OBody sends your `IOBodyReadinessEventListener` an `OBodyIsNoLongerReady` event. */
+            std::string_view presetName;
         };
 
         /** This is an interface for receiving events from OBody regarding the state of actors.

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -61,6 +61,8 @@
                 }
             };
         ```
+
+        See the end of this file for the licence that this header file is made available under.
 */
 
 /* A note for implementers:
@@ -533,3 +535,680 @@ namespace OBody {
         }  // namespace SKSEMessages
     }  // namespace API
 }  // namespace OBody
+
+/*
+GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+*/

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -221,6 +221,18 @@ namespace OBody {
                 by OBody for the current distribution key, otherwise it will force OBody to process
                 the actor for the current distribution key, in accordance with OBody's configuration. */
             virtual void EnsureActorIsProcessed(Actor* actor) = 0;
+
+            /** This is used to reapply any OBody morphs that are or were applied to an actor,
+                such that the actor's morph will be as they should, according to the preset assigned to
+                them; if no preset is assigned to them, a preset will be assigned to them in the usual
+                fashion. `RemoveOBodyMorphsFromActor` can be used to reverse this operation. */
+            virtual void ApplyOBodyMorphsToActor(Actor* actor) = 0;
+
+            /** This is used to remove any OBody morphs that are applied to an actor, such that the
+                actor's morph will be as though OBody had never morphed the actor at all.
+                `ApplyOBodyMorphsToActor` can be used to reverse this operation.
+                Any per-actor configuration, such as the applied preset, will be retained for the actor. */
+            virtual void RemoveOBodyMorphsFromActor(Actor* actor) = 0;
         };
 
         /** This is an interface for receiving events from OBody regarding

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -351,6 +351,17 @@ namespace OBody {
             */
             struct OnActorGenerated {
                 struct Payload {
+                    /** This will be null if OBody itself was responsible for this event being fired.
+                        Otherwise, this is the `IPluginInterface` that was responsible for this event being triggered.
+
+                        There is a special `IPluginInterface` instance which OBody will set in this field
+                        if this event was effected by OBody's Papyrus functions (the OBodyNative script).
+                        You can identify that instance by its `owner` string, which is: "_Papyrus".
+
+                        You can use this field to avoid acting upon changes that your own plugin effected,
+                        or to avoid stepping on the toes of other mods that are making changes.*/
+                    IPluginInterfaceVersionIndependent* responsiblePluginInterface;
+
                     /** The name of the BodySlide preset that was assigned to the actor.
                         Note that this is the name of the BodySlide preset as defined within the XML
                         of the BodySlide slider presets file, and not the name of the slider presets file itself.
@@ -443,6 +454,9 @@ namespace OBody {
             */
             struct OnActorClothingUpdate {
                 struct Payload {
+                    /** Refer to the documentation of `responsiblePluginInterface` for the `OnActorGenerated` event. */
+                    IPluginInterfaceVersionIndependent* responsiblePluginInterface;
+
                     /** The equipment that is being equipped or unequipped by the actor,
                         check the flags for which it is. This will not be null. */
                     const TESForm* changedEquipment;
@@ -484,7 +498,10 @@ namespace OBody {
                 `OBodyNative.AddClothesOverlay` or `OBodyNative.RemoveClothesOverlay`.
             */
             struct OnORefitForcefullyChanged {
-                struct Payload {};
+                struct Payload {
+                    /** Refer to the documentation of `responsiblePluginInterface` for the `OnActorGenerated` event. */
+                    IPluginInterfaceVersionIndependent* responsiblePluginInterface;
+                };
 
                 enum Flags : uint64_t {
                     None = 0,
@@ -511,7 +528,10 @@ namespace OBody {
                 (Implicitly, this means that ORefit is not active for the actor).
             */
             struct OnActorMorphsCleared {
-                struct Payload {};
+                struct Payload {
+                    /** Refer to the documentation of `responsiblePluginInterface` for the `OnActorGenerated` event. */
+                    IPluginInterfaceVersionIndependent* responsiblePluginInterface;
+                };
 
                 enum Flags : uint64_t { None = 0 };
 

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -1,0 +1,535 @@
+#pragma once
+
+#include <limits>
+#include <string_view>
+
+/**
+    This header is a C++ API for interoperating with OBody via a SKSE plugin.
+
+    The expected usage of this header is for you to copy it wholesale into your project and use it as-is.
+    There is no need to involve any other portion of OBody's source code for use of this API.
+
+    Skyrim game types, such as `Actor` and `TESForm` are used by this header, but are left undefined
+    so that you can define them yourself before including this header. Such as by including the
+    headers of the likes of CommonLibSSE or SKSE64, for example.
+
+    The overall usage of this API is relatively simple:
+        After SKSE has sent a `kPostPostLoad` message to your plugin, you can send a `RequestPluginInterface`
+        message along with an `IOBodyReadinessEventListener` instance to OBody, and if OBody is installed,
+        and your request is valid, OBody will write a pointer to an `IPluginInterface` instance
+        through your supplied pointer.
+        That object is your primary gateway to interoperating with OBody.
+
+        But do note that an `IPluginInterface` instance can be used only when it is safe to do so--
+        you can be notified of when it is safe to do so via the `IOBodyReadinessEventListener` instance
+        that you supply in a `RequestPluginInterface` message.
+
+        For example, this is how you would request a plugin interface when using CommonLibSSE:
+        ```
+            if (message->type == SKSE::MessagingInterface::kPostPostLoad) {
+                OBody::API::SKSEMessages::RequestPluginInterface req{};
+                req.version = OBody::API::PluginAPIVersion::Latest;
+                req.pluginInterface = &yourGlobalState.obodyAPI;
+                req.readinessEventListener = &yourGlobalState.obodyReadinessListener;
+
+                assert(yourGlobalState.obodyAPI == nullptr);
+
+                SKSE::GetMessagingInterface()->Dispatch(decltype(req)::type, &req, sizeof(decltype(req)), "OBody");
+
+                if (yourGlobalState.obodyAPI != nullptr) {
+                    // OBody is installed!
+                }
+            }
+
+            // ...
+
+            class OBodyReadinessListener : public OBody::API::IOBodyReadinessEventListener {
+            public:
+                bool initialised = false;
+
+                virtual void OBodyIsReady() override {
+                    yourGlobalState.obodyIsSafeToUse = true;
+
+                    if (!this->initialised) {
+                        yourGlobalState.obodyAPI->RegisterEventListener(yourGlobalState.actorChangeListener);
+                        this->initialised = true;
+                    }
+                }
+
+                virtual void OBodyIsNoLongerReady() override {
+                    yourGlobalState.obodyIsSafeToUse = false;
+                }
+            };
+        ```
+*/
+
+/* A note for implementers:
+   Be mindful of ABI-compatibility when making changes to this header, if you do any of the following
+   without introducing a new `PluginAPIVersion` and corresponding versioned virtual classes, you risk
+   breaking mods that use this API:
+     * Changing the order of virtual methods or members in an aggregate type.
+     * Removing virtual methods or members from an aggregate type.
+     * Changing the values of an enum type or of constant values.
+     * Changing how parameters are passed to a function, or how its result is returned;
+         see: https://learn.microsoft.com/cpp/build/x64-calling-convention
+     * Increasing the required alignment of an aggregate type.
+
+   Stick to appending virtual methods and members to the end of aggregate types and all will be grand.
+*/
+
+namespace OBody {
+    namespace API {
+        /** This represents a version of the OBody plugin-API and is unrelated to the version of OBody proper.
+            These version numbers signify how this API is to be used.
+            New versions will be introduced when breaking changes are made to the API, so that it's feasible to
+            update the API without breaking SKSE plugins that were compiled for older versions.
+        */
+        enum class PluginAPIVersion { Invalid = 0, v1 = 1, Latest = v1 };
+
+        class IActorChangeEventListener;
+        /** See the documentation for `IPluginInterface`, this is its base class purely to make it
+            easier to maintain ABI-compatibility.
+
+            As suggested by the name of this class, it's layout will remain
+            compatible with all versions of the OBody plugin API.
+        */
+        class IPluginInterfaceVersionIndependent {
+        public:
+            /** This is a string that identifies the mod which requested this `IPluginInterface`.
+                By default, this is the name of the mod's SKSE plugin.
+
+                Do not change this string directly, if you must change it: use the `SetOwner` method.
+                This is exposed as a field solely to reduce the overhead of reading it.
+
+                This string must remain valid for the duration of the `IPluginInterface`'s lifetime. */
+            const char* owner;
+
+            /** This is a pointer-sized field that you can use for whatever you want.
+                OBody does not care about the value of the field, it does not use it.
+                By default this is null. */
+            void* context = nullptr;
+
+            /** This returns the version of the OBody plugin-API that this `IPluginInterface` implements. */
+            virtual PluginAPIVersion PluginAPIVersion() = 0;
+
+            /** This is used to change the value of the `owner`field. It returns the value of the `owner` parameter. */
+            virtual const char* SetOwner(const char* owner) = 0;
+        };
+
+        /** This is the primary interface of the plugin-API.
+            This is what you get in return from sending a `RequestPluginInterface` message to `OBody`.
+
+            You can acquire a plugin interface after SKSE has sent a `kPostPostLoad` message to your plugin,
+            but note that it will not be safely usable until OBody sends your `IOBodyReadinessEventListener` instance
+            an `OBodyIsReady` event.
+
+            Unless otherwise stated, all the methods provided by this type are thread-safe.
+        */
+        class IPluginInterface : public IPluginInterfaceVersionIndependent {
+        public:
+            /** This is used to check whether OBody considers an actor to be naked or not.
+                If you're calling this in the context of a `TESEquipEvent`
+                event sink, see the 3-argument overload of this method. */
+            virtual bool ActorIsNaked(Actor* actor) = 0;
+
+            /** This is used to check whether OBody considers an actor to be naked or not.
+                If you're calling this in the context of a `TESEquipEvent`
+                event sink, note that the game will not yet have actually [un]equipped the form from
+                the actor, thus you'll need to pass to OBody whether the event is an unequip or an equip event,
+                and the armor that's being [un]equipped so that OBody can properly assess whether the
+                actor is naked or not. */
+            virtual bool ActorIsNaked(Actor* actor, bool actorIsEquippingArmor, const TESForm* armor) = 0;
+
+            /** This is used to check whether ORefit is currently applied to an actor or not. */
+            virtual bool ActorHasORefitApplied(Actor* actor) = 0;
+
+            /** This is used to check whether OBody has processed an actor or not.
+                Wherein an actor is considered processed if they have OBody morphs
+                for the current distribution applied to them.
+                A blacklisted actor may be considered as processed. */
+            virtual bool ActorIsProcessed(Actor* actor) = 0;
+
+            /** This is used to check whether OBody has blacklisted an actor or not.
+                A blacklisted actor is an actor that OBody is not automatically applying presets to.
+                A user may manually apply a preset to a blacklisted actor. */
+            virtual bool ActorIsBlacklisted(Actor* actor) = 0;
+
+            /** This is used to check whether ORefit is globally enabled for OBody or not. */
+            virtual bool IsORefitEnabled() = 0;
+
+            /** `RegisterEventListener` and `DeregisterEventListener` are used
+                 to subscribe and unsubscribe to and from events from OBody.
+
+                 Registering and deregistering event-listeners acquires an exclusive lock internally,
+                 so if you want to disable and re-enable an event-listener frequently, you should do
+                 so internally in that event-listener.
+
+                 Whilst these methods are thread-safe, you MUST not call these methods for
+                 an `IXYZEventListener` instance from within the context
+                 of an `IXYZEventListener` method called by OBody,
+                 because doing so will invalidate the iterator that OBody is acting upon.
+
+                 Rely on the order in which OBody sends events to different listeners for the same event
+                 at your own peril.
+                 The order in which OBody send different events in is deterministic.
+            */
+
+            /** This will make OBody start sending events to `eventListener`,
+                returning whether the registration was successful or not.
+                If this is called multiple times with the same listener, that listener will receive duplicated events.
+
+                The `eventListener` reference passed to this method MUST remain valid until it is passed
+                to `DeregisterEventListener` (or until the game's process terminates). */
+            virtual bool RegisterEventListener(IActorChangeEventListener& eventListener) = 0;
+
+            /** This will make OBody stop sending events to `eventListener`,
+                returning whether any listeners were deregistered or not. */
+            virtual bool DeregisterEventListener(IActorChangeEventListener& eventListener) = 0;
+
+            /** This is used to check whether OBody is sending events to `eventListener` or not. */
+            virtual bool HasRegisteredEventListener(IActorChangeEventListener& eventListener) = 0;
+        };
+
+        /** This is an interface for receiving events from OBody regarding
+            whether OBody is ready for other mods to interact with it via the plugin-API or not.
+
+            This event-listener MUST be used to be notified of when it is and isn't safe to use `IPluginInterface`s.
+
+            At various stages of the game's life-cycle, OBody may need to rearrange its state,
+            and during those periods usage of OBody's plugin-API via an `IPluginInterface` will be unsafe,
+            causing bugs at best and memory corruption at worst (if multi-threading is involved).
+            The most notable period wherein this is so is when a game is saved or loaded.
+
+            If you want to safely interact with OBody's plugin-API in response to the game saving or loading,
+            you should do so by reacting to these events.
+
+            Note that when Obody calls the methods of an instance of this class, that method and the functions it calls
+            MUST not send a `RequestPluginInterface` SKSE message to OBody,
+            because doing so will invalidate the iterator that OBody is acting upon.
+        */
+        class IOBodyReadinessEventListener {
+        public:
+            /** The OBodyIsReady event is sent just after OBody has become ready for the plugin-API
+                to be used and has sent an `OBodyIsBecomingReady` event to every `IOBodyReadinessEventListener`,
+                or when OBody reponds to a `RequestPluginInterface` SKSE message when it is already ready.
+
+                It is safe to use `IPluginInterface` instances from the moment this method is called.
+            */
+            virtual void OBodyIsReady() = 0;
+
+            /** The OBodyIsNoLongerReady event is sent when OBody stops being ready for the plugin-API to be used.
+
+                It is not safe to use `IPluginInterface` instances from the moment this method is called.
+            */
+            virtual void OBodyIsNoLongerReady() = 0;
+
+            /** The OBodyIsBecomingReady event is sent just before OBody transitions from being unready
+                to being ready,
+                or when OBody reponds to a `RequestPluginInterface` SKSE message when it is already ready.
+
+                It is safe to use `IPluginInterface` instances after every `IOBodyReadinessEventListener`
+                has handled this event, which is signaled via the `OBodyIsReady` event.
+
+                The purpose of this event is to give you a chance to set-up any state that you may
+                need to set-up in order to handle events originating from other `IPluginInterface`s
+                _before_ you have received the `OBodyIsReady` event.
+
+                For an example of why that may be needed, consider this scenario:
+                    There are two mods using the OBody plugin-API: Mod-A, and Mod-B.
+                    The game was saved by the player, and so OBody became unready, and Mod-B tore down
+                    some of its state that it requires for its `IActorChangeEventListener` instance.
+                    OBody then becomes ready again, and Mod-B sets up its state in response to the
+                    `OBodyIsBecomingReady` event.
+                    Then, when Mod-A receives its `OBodyIsReady` event, it uses its `IPluginInterface` to change
+                    an actor, which causes Mod-B's `IActorChangeEventListener` to receive an event
+                    BEFORE Mod-B has had a chance to receive the `OBodyIsReady` event.
+                    If Mod-B hadn't had a chance to set-up its state via the `OBodyIsBecomingReady` event
+                    a bug would have occurred.
+            */
+            virtual void OBodyIsBecomingReady() {};
+
+            /** The OBodyIsBecomingUnready event is sent just before OBody transitions from being ready
+                to being unready.
+
+                It is safe to use `IPluginInterface` instances when this method is called,
+                and it remains safe to do so until the `OBodyIsNoLongerReady` event is sent.
+
+                This event is effectively OBody yelling, "Last orders, please!".
+            */
+            virtual void OBodyIsBecomingUnready() {};
+        };
+
+        /** This is an interface for receiving events from OBody regarding the state of actors.
+
+            If you want to keep your plugin's state in sync with OBody's state for actors you should
+            implement this class and pass an instance of it to `IPluginInterface::RegisterEventListener`.
+
+            When registered with OBody, OBody will call the methods defined by an instance of this class
+            to signal the occurrence of certain events.
+
+            Note that when Obody calls the methods of an instance of this class, that method and the functions it calls
+            MUST not call `IPluginInterface::RegisterEventListener` or `IPluginInterface::DeregisterEventListener`
+            for an `IActorChangeEventListener` instance, because doing so will invalidate the iterator that OBody
+            is acting upon.
+
+            The virtual methods of this class all have default implementations, so you need only implement the events
+            you care about.
+
+            These events have a consistent interface; an actor is passed as the first parameter;
+            then a 64-bit bit-packed structure; and then a reference to a payload with extra data.
+            This maximises performance as all the arguments are passed via registers, and the payload structure
+            can be expanded without breaking ABI compatibility.
+            Every event returns a response, which OBody may or may not use.
+            The payload is mutable as it may be used as an extended return-channel in future, if needed.
+        */
+        class IActorChangeEventListener {
+        public:
+            /** The OnActorGenerated event is sent just after the assignment of a preset to an actor,
+                and after OBody has either: applied the preset's morphs to the actor;
+                or queued those morphs to be applied to the actor.
+                (That is to say, the morphs may or not be visible to the player when you receive this event).
+
+                This event is not sent when an actor's preset is reassigned but the actor is not regenerated.
+                See the `OnActorPresetChangedWithoutGeneration` event for that scenario.
+            */
+            struct OnActorGenerated {
+                struct Payload {
+                    /** The name of the BodySlide preset that was assigned to the actor.
+                        Note that this is the name of the BodySlide preset as defined within the XML
+                        of the BodySlide slider presets file, and not the name of the slider presets file itself.
+
+                        This is a `string_view`, but the string it points to is null-terminated,
+                        so it can be used as C-style string.
+                        The data that this `string_view` points to is guaranteed to be valid
+                        only until the event-listener's method returns.
+
+                        For the `OnActorGenerated` event specifically, this is guaranteed to be non-null and not empty,
+                        for other events this may be null if the actor has no preset applied to them. */
+                    const std::string_view presetName;
+                };
+
+                enum Flags : uint64_t {
+                    None = 0,
+                    /** This bit will be set if OBody considers the actor to be clothed. Elsewise the actor is naked. */
+                    IsClothed = 1 << 0,
+                    /** This bit will be set if ORefit is currently applied to the actor. */
+                    IsORefitApplied = 1 << 1,
+                    /** This bit will be set if ORefit is globally enabled for OBody. */
+                    IsORefitEnabled = 1 << 2
+                };
+
+                enum class Response : uint64_t {
+                    /** The default response: nothing special happens if you return it. */
+                    None = 0
+                };
+            };
+
+            /** OBody will call this method to notify the listener of `OnActorGenerated` events. */
+            virtual OnActorGenerated::Response OnActorGenerated(Actor* actor, OnActorGenerated::Flags flags,
+                                                                OnActorGenerated::Payload& payload) {
+                return OnActorGenerated::Response::None;
+            }
+
+            /** The OnActorPresetChangedWithoutGeneration event is sent just after the assignment of a preset
+                to an actor, if the actor is not also being regenerated.
+                This event is also sent when a preset is unassigned from an actor.
+            */
+            struct OnActorPresetChangedWithoutGeneration {
+                struct Payload {
+                    /** Refer to the documentation of `responsiblePluginInterface` for the `OnActorGenerated` event. */
+                    IPluginInterfaceVersionIndependent* responsiblePluginInterface;
+
+                    /** The name of the BodySlide preset that was assigned to the actor.
+                        Note that this is the name of the BodySlide preset as defined within the XML
+                        of the BodySlide slider presets file, and not the name of the slider presets file itself.
+
+                        This is a `string_view`, but the string it points to is null-terminated,
+                        so it can be used as C-style string.
+                        The data that this `string_view` points to is guaranteed to be valid
+                        only until the event-listener's method returns.
+
+                        If this string is null or empty,
+                        it means that a preset has been unassigned from the actor
+                        and the actor did not previously have a preset assigned to them. */
+                    const std::string_view presetName;
+                };
+
+                enum Flags : uint64_t {
+                    None = 0,
+                    /** If this bit is set, this event signals that a preset was unassigned from the actor.
+                        And that the `presetName` field contains the name of the preset that the actor had
+                        before it was unassigned. */
+                    PresetWasUnassigned = 1 << 0
+                };
+
+                enum class Response : uint64_t {
+                    /** The default response: nothing special happens if you return it. */
+                    None = 0
+                };
+            };
+
+            /** OBody will call this method to notify the listener of `OnActorPresetChangedWithoutGeneration` events. */
+            virtual OnActorPresetChangedWithoutGeneration::Response OnActorPresetChangedWithoutGeneration(
+                Actor* actor, OnActorPresetChangedWithoutGeneration::Flags flags,
+                OnActorPresetChangedWithoutGeneration::Payload& payload) {
+                return OnActorPresetChangedWithoutGeneration::Response::None;
+            }
+
+            /** The OnActorClothingUpdate event is sent when the state of an actor's equipped clothing/armour changes.
+                This event allows a listener to keep up-to-date on whether or not ORefit is active on actors,
+                and whether or not OBody considers an actor to be naked or clothed.
+
+                Note that internally this event is called from within the context of a `TESEquipEvent` event sink,
+                and thus if the listener is querying the worn equipment of the actor, it may need to consider the
+                equipment that is being [un]equipped by the actor, which can be accessed in the payload of this event.
+                (See also `IPluginInterface::ActorIsNaked`).
+            */
+            struct OnActorClothingUpdate {
+                struct Payload {
+                    /** The equipment that is being equipped or unequipped by the actor,
+                        check the flags for which it is. This will not be null. */
+                    const TESForm* changedEquipment;
+                };
+
+                enum Flags : uint64_t {
+                    None = 0,
+                    /** This bit will be set if OBody considers the actor to be clothed. Elsewise the actor is naked. */
+                    IsClothed = 1 << 0,
+                    /** This bit will be set if ORefit is currently applied to the actor. */
+                    IsORefitApplied = 1 << 1,
+                    /** This bit will be set if ORefit is globally enabled for OBody. */
+                    IsORefitEnabled = 1 << 2,
+                    /** This bit will be set if OBody considers the actor to be processed.
+                        (See `IPluginInterface::ActorIsProcessed`). */
+                    IsProcessed = 1 << 3,
+                    /** This bit will be set if OBody considers the actor to be blacklisted.
+                        (See `IPluginInterface::ActorIsBlacklisted`). */
+                    IsBlacklisted = 1 << 4,
+                    /** This bit will be set if the actor is equipping equipment, otherwise the actor is unequipping. */
+                    ActorIsEquipping = 1 << 5
+                };
+
+                enum class Response : uint64_t {
+                    /** The default response: nothing special happens if you return it. */
+                    None = 0
+                };
+            };
+
+            /** OBody will call this method to notify the listener of `OnActorClothingUpdate` events. */
+            virtual OnActorClothingUpdate::Response OnActorClothingUpdate(Actor* actor,
+                                                                          OnActorClothingUpdate::Flags flags,
+                                                                          OnActorClothingUpdate::Payload& payload) {
+                return OnActorClothingUpdate::Response::None;
+            }
+
+            /** The OnORefitForcefullyChanged event is sent when ORefit is forcefully enabled or disabled
+                for an actor; typically as the result of a Papyrus script calling
+                `OBodyNative.AddClothesOverlay` or `OBodyNative.RemoveClothesOverlay`.
+            */
+            struct OnORefitForcefullyChanged {
+                struct Payload {};
+
+                enum Flags : uint64_t {
+                    None = 0,
+                    /** This bit will be set if ORefit is currently applied to the actor. */
+                    IsORefitApplied = 1 << 1,
+                    /** This bit will be set if ORefit is globally enabled for OBody. */
+                    IsORefitEnabled = 1 << 2
+                };
+
+                enum class Response : uint64_t {
+                    /** The default response: nothing special happens if you return it. */
+                    None = 0
+                };
+            };
+
+            /** OBody will call this method to notify the listener of `OnORefitForcefullyChanged` events. */
+            virtual OnORefitForcefullyChanged::Response OnORefitForcefullyChanged(
+                Actor* actor, OnORefitForcefullyChanged::Flags flags, OnORefitForcefullyChanged::Payload& payload) {
+                return OnORefitForcefullyChanged::Response::None;
+            }
+
+            /** The OnActorMorphsCleared event is sent when an actor's OBody morphs are cleared;
+                typically as the result of a Papyrus script calling `OBodyNative.ResetActorOBodyMorphs`.
+                (Implicitly, this means that ORefit is not active for the actor).
+            */
+            struct OnActorMorphsCleared {
+                struct Payload {};
+
+                enum Flags : uint64_t { None = 0 };
+
+                enum class Response : uint64_t {
+                    /** The default response: nothing special happens if you return it. */
+                    None = 0
+                };
+            };
+
+            /** OBody will call this method to notify the listener of `OnActorMorphsCleared` events. */
+            virtual OnActorMorphsCleared::Response OnActorMorphsCleared(Actor* actor, OnActorMorphsCleared::Flags flags,
+                                                                        OnActorMorphsCleared::Payload& payload) {
+                return OnActorMorphsCleared::Response::None;
+            }
+        };
+
+        /** These structures are to be used to send messages to OBody via SKSE's messaging interface.
+            Their general usage is such that you allocate the structure somewhere--likely on the stack--
+            and the structure's address is then used for the message's `data` pointer, and the `sizeof`
+            of the structure is used for the message's `dataLen`.
+
+            See the top of this header for an example involving the `RequestPluginInterface` message.
+        */
+        namespace SKSEMessages {
+            /** The `RequestPluginInterface` message is used to request an `IPluginInterface` instance from OBody,
+                thus this can be thought of as the entry-point to OBody's plugin-API.
+
+                Before sending this message, you must set the `version` field to the version of the plugin API
+                that your SKSE plugin supports; this allows OBody to return a different `IPluginInterface` instance
+                to your plugin according to that version, which permits OBody to update and alter its API without
+                breaking backwards compatibility with your already-compiled mod.
+
+                Secondly, you must supply a valid pointer to an `IOBodyReadinessEventListener` instance
+                via the `readinessEventListener` field.
+                The `IOBodyReadinessEventListener` instance pointed-to by this field must remain valid
+                until the process terminates.
+
+                In response to this message, OBody will write through the pointer of the `pluginInterface` field.
+                If your message was valid and OBody can satisfy it, the pointed-to `pluginInterface` will be a pointer
+                to a valid `IPluginInterface` instance.
+                Otherwise, if your message was invalid or could not be satisfied, such as if you requested a version
+                that is not a valid `PluginAPIVersion` value, or OBody has stopped supporting your requested version,
+                then `pluginInterface` will not be written through.
+                Likewise if you failed to supply an `IOBodyReadinessEventListener`.
+                If the `dataLen` value you send is smaller than three pointers,
+                then OBody will not respond to the message.
+
+                The `IPluginInterface` instance you receive is not safe to use
+                until the `IOBodyReadinessEventListener` instance you supplied receives an `OBodyIsReady` event.
+                See the documentation for `IOBodyReadinessEventListener` for more detail.
+
+                Whilst the handler that receives this message is thread-safe,
+                you MUST not send this message to OBody from within the context
+                of an `IOBodyReadinessEventListener` method called by OBody,
+                because doing so will invalidate the iterator that OBody is acting upon.
+
+                The reason why `pluginInterface` is a pointer to a pointer that is written through,
+                instead of simply returning a pointer via the message, is so that the `IPluginInterface*`
+                can be written directly to a location accessible by your `IOBodyReadinessEventListener` instance.
+                This is important as the `OBodyIsReady` event can be sent before you receive a response for the message.
+            */
+            struct RequestPluginInterface {
+                /** The value for the `type` of the SKSE message. */
+                static constexpr uint32_t type = 0xc0B0D9cc;
+
+                /** The version of the plugin that you support; see above. (You send this). */
+                PluginAPIVersion version;
+
+                /** A pointer to a pointer to an `IPluginInterface` instance; see above. (You send this).
+                    The `IPluginInterface*` that is written through this pointer will have been allocated by `new`. */
+                IPluginInterface** pluginInterface;
+
+                /** A pointer to an `IOBodyReadinessEventListener` instance; see above. (You send this). */
+                IOBodyReadinessEventListener* readinessEventListener;
+            };
+        }  // namespace SKSEMessages
+    }  // namespace API
+}  // namespace OBody

--- a/src/API/API.h
+++ b/src/API/API.h
@@ -215,6 +215,12 @@ namespace OBody {
                 can be used to return only a subset of the preset names. */
             virtual size_t GetPresetNames(PresetCategory category, std::string_view* buffer, size_t bufferLength,
                                           size_t offset = 0, size_t limit = (std::numeric_limits<size_t>::max)()) = 0;
+
+            /** This is used to ensure that OBody processes an actor for the current distribution key.
+                That is to say, this operation does nothing if the actor has already been processed
+                by OBody for the current distribution key, otherwise it will force OBody to process
+                the actor for the current distribution key, in accordance with OBody's configuration. */
+            virtual void EnsureActorIsProcessed(Actor* actor) = 0;
         };
 
         /** This is an interface for receiving events from OBody regarding

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -103,5 +103,9 @@ namespace OBody {
         void PluginInterface::RemoveOBodyMorphsFromActor(Actor* a_actor) {
             Body::OBody::GetInstance().ClearActorMorphs(a_actor, this);
         }
+
+        void PluginInterface::ForcefullyChangeORefitForActor(Actor* a_actor, bool orefitShouldBeApplied) {
+            Body::OBody::GetInstance().ForcefullyChangeORefit(a_actor, orefitShouldBeApplied, this);
+        }
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -1,0 +1,49 @@
+#include "API/PluginInterface.h"
+#include "Body/Body.h"
+
+namespace OBody {
+    namespace API {
+        PluginInterface::PluginInterface(const char* owner, void* context) {
+            this->owner = owner;
+            this->context = context;
+        }
+
+        PluginAPIVersion PluginInterface::PluginAPIVersion() { return PluginAPIVersion::v1; }
+
+        const char* PluginInterface::SetOwner(const char* owner) { return this->owner = owner; }
+
+        bool PluginInterface::ActorIsNaked(RE::Actor* a_actor) {
+            return Body::OBody::GetInstance().IsNaked(a_actor, false, nullptr);
+        }
+
+        bool PluginInterface::ActorIsNaked(RE::Actor* a_actor, bool a_equippingArmor, const TESForm* a_equippedArmor) {
+            return Body::OBody::GetInstance().IsNaked(a_actor, !a_equippingArmor, a_equippedArmor);
+        }
+
+        bool PluginInterface::ActorHasORefitApplied(RE::Actor* a_actor) {
+            return Body::OBody::GetInstance().IsClotheActive(a_actor);
+        };
+
+        bool PluginInterface::ActorIsProcessed(RE::Actor* a_actor) {
+            return Body::OBody::GetInstance().IsProcessed(a_actor);
+        };
+
+        bool PluginInterface::ActorIsBlacklisted(RE::Actor* a_actor) {
+            return Body::OBody::GetInstance().IsBlacklisted(a_actor);
+        };
+
+        bool PluginInterface::IsORefitEnabled() { return Body::OBody::GetInstance().setRefit; }
+
+        bool PluginInterface::RegisterEventListener(IActorChangeEventListener& eventListener) {
+            return Body::OBody::GetInstance().AttachEventListener(eventListener);
+        }
+
+        bool PluginInterface::DeregisterEventListener(IActorChangeEventListener& eventListener) {
+            return Body::OBody::GetInstance().DetachEventListener(eventListener);
+        }
+
+        bool PluginInterface::HasRegisteredEventListener(IActorChangeEventListener& eventListener) {
+            return Body::OBody::GetInstance().IsEventListenerAttached(eventListener);
+        }
+    }  // namespace API
+}  // namespace OBody

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -95,5 +95,13 @@ namespace OBody {
         void PluginInterface::EnsureActorIsProcessed(Actor* a_actor) {
             Body::OBody::GetInstance().GenerateActorBody(a_actor, this);
         }
+
+        void PluginInterface::ApplyOBodyMorphsToActor(Actor* a_actor) {
+            Body::OBody::GetInstance().ReapplyActorMorphs(a_actor, this);
+        }
+
+        void PluginInterface::RemoveOBodyMorphsFromActor(Actor* a_actor) {
+            Body::OBody::GetInstance().ClearActorMorphs(a_actor, this);
+        }
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -91,5 +91,9 @@ namespace OBody {
 
             return index;
         }
+
+        void PluginInterface::EnsureActorIsProcessed(Actor* a_actor) {
+            Body::OBody::GetInstance().GenerateActorBody(a_actor, this);
+        }
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -45,5 +45,51 @@ namespace OBody {
         bool PluginInterface::HasRegisteredEventListener(IActorChangeEventListener& eventListener) {
             return Body::OBody::GetInstance().IsEventListenerAttached(eventListener);
         }
+
+        void PluginInterface::GetPresetCounts(PresetCounts& payload) {
+            const auto& presetContainer{PresetManager::PresetContainer::GetInstance()};
+            payload.female = presetContainer.femalePresets.size();
+            payload.femaleBlacklisted = presetContainer.blacklistedFemalePresets.size();
+            payload.male = presetContainer.malePresets.size();
+            payload.maleBlacklisted = presetContainer.blacklistedMalePresets.size();
+        }
+
+        size_t PluginInterface::GetPresetNames(PresetCategory category, std::string_view* buffer, size_t bufferLength,
+                                               size_t offset, size_t limit) {
+            const auto& presetContainer{PresetManager::PresetContainer::GetInstance()};
+            const PresetManager::PresetSet* presets;
+
+            switch (category) {
+                case PresetCategory::PresetCategoryFemale:
+                    presets = &presetContainer.femalePresets;
+                    break;
+                case PresetCategory::PresetCategoryFemaleBlacklisted:
+                    presets = &presetContainer.blacklistedFemalePresets;
+                    break;
+                case PresetCategory::PresetCategoryMale:
+                    presets = &presetContainer.malePresets;
+                    break;
+                case PresetCategory::PresetCategoryMaleBlacklisted:
+                    presets = &presetContainer.blacklistedMalePresets;
+                    break;
+                default:
+                    presets = nullptr;
+            }
+
+            if (presets == nullptr) {
+                return 0;
+            }
+
+            size_t presetCount = presets->size();
+            limit = std::min(bufferLength, limit);
+
+            size_t index = 0;
+            for (size_t presetIndex = offset; (presetIndex < presetCount) & (index < limit); ++presetIndex, ++index) {
+                const auto& preset = (*presets)[presetIndex];
+                buffer[index] = {preset.name.data(), preset.name.size()};
+            }
+
+            return index;
+        }
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -35,6 +35,8 @@ namespace OBody {
             virtual void RemoveOBodyMorphsFromActor(Actor* actor) override;
 
             virtual void ForcefullyChangeORefitForActor(Actor* actor, bool orefitShouldBeApplied) override;
+
+            virtual void GetPresetAssignedToActor(Actor* actor, PresetAssignmentInformation& payload) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -24,6 +24,10 @@ namespace OBody {
             virtual bool RegisterEventListener(IActorChangeEventListener& eventListener) override;
             virtual bool DeregisterEventListener(IActorChangeEventListener& eventListener) override;
             virtual bool HasRegisteredEventListener(IActorChangeEventListener& eventListener) override;
+
+            virtual void GetPresetCounts(PresetCounts& payload) override;
+            virtual size_t GetPresetNames(PresetCategory category, std::string_view* buffer, size_t bufferLength,
+                                          size_t offset, size_t limit) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -30,6 +30,9 @@ namespace OBody {
                                           size_t offset, size_t limit) override;
 
             virtual void EnsureActorIsProcessed(Actor* actor) override;
+
+            virtual void ApplyOBodyMorphsToActor(Actor* actor) override;
+            virtual void RemoveOBodyMorphsFromActor(Actor* actor) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -28,6 +28,8 @@ namespace OBody {
             virtual void GetPresetCounts(PresetCounts& payload) override;
             virtual size_t GetPresetNames(PresetCategory category, std::string_view* buffer, size_t bufferLength,
                                           size_t offset, size_t limit) override;
+
+            virtual void EnsureActorIsProcessed(Actor* actor) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -33,6 +33,8 @@ namespace OBody {
 
             virtual void ApplyOBodyMorphsToActor(Actor* actor) override;
             virtual void RemoveOBodyMorphsFromActor(Actor* actor) override;
+
+            virtual void ForcefullyChangeORefitForActor(Actor* actor, bool orefitShouldBeApplied) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -37,6 +37,7 @@ namespace OBody {
             virtual void ForcefullyChangeORefitForActor(Actor* actor, bool orefitShouldBeApplied) override;
 
             virtual void GetPresetAssignedToActor(Actor* actor, PresetAssignmentInformation& payload) override;
+            virtual bool AssignPresetToActor(Actor* actor, AssignPresetPayload& payload) override;
         };
     }  // namespace API
 }  // namespace OBody

--- a/src/API/PluginInterface.h
+++ b/src/API/PluginInterface.h
@@ -1,0 +1,29 @@
+#pragma once
+
+using Actor = RE::Actor;
+using TESForm = RE::TESForm;
+#include "API/API.h"
+
+namespace OBody {
+    namespace API {
+        class PluginInterface : public IPluginInterface {
+        public:
+            PluginInterface(const char* owner, void* context = nullptr);
+
+            virtual ::OBody::API::PluginAPIVersion PluginAPIVersion() override;
+            virtual const char* SetOwner(const char* owner) override;
+
+            virtual bool ActorIsNaked(RE::Actor* a_actor) override;
+            virtual bool ActorIsNaked(RE::Actor* a_actor, bool a_equippingArmor,
+                                      const RE::TESForm* a_equippedArmor) override;
+            virtual bool ActorHasORefitApplied(RE::Actor* a_actor) override;
+            virtual bool ActorIsProcessed(RE::Actor* a_actor) override;
+            virtual bool ActorIsBlacklisted(RE::Actor* a_actor) override;
+            virtual bool IsORefitEnabled() override;
+
+            virtual bool RegisterEventListener(IActorChangeEventListener& eventListener) override;
+            virtual bool DeregisterEventListener(IActorChangeEventListener& eventListener) override;
+            virtual bool HasRegisteredEventListener(IActorChangeEventListener& eventListener) override;
+        };
+    }  // namespace API
+}  // namespace OBody

--- a/src/ActorTracker/ActorTracker.cpp
+++ b/src/ActorTracker/ActorTracker.cpp
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ActorTracker/ActorTracker.h"
+
+ActorTracker::Registry ActorTracker::Registry::instance;
+
+namespace ActorTracker {
+    Registry& Registry::GetInstance() { return instance; }
+}  // namespace ActorTracker

--- a/src/ActorTracker/ActorTracker.h
+++ b/src/ActorTracker/ActorTracker.h
@@ -5,14 +5,24 @@
 
 namespace ActorTracker {
     struct ActorState {
-        // This is set when events are being sent to `IActorChangeEventListener` instances for this actor.
-        // We use this bit to prevent the sending of recursive events for an actor--should an event-listener
-        // do something that would trigger a recursive event.
-        // This is particularly important for the `OnActorClothingUpdate` event, as if an event-listener equips
-        // or unequips armour in response to it: it can easily cause an infinite loop of `TESEquipEvent`s,
-        // which would freeze the game until it crashes from a stack overflow.
-        uint32_t actorChangeEventsAreBeingSent : 1;
-        uint32_t unusedSpareBitsForLaterUse : 31;
+        union {
+            uint32_t value = 0;
+
+            struct {
+                // This is set when events are being sent to `IActorChangeEventListener` instances for this actor.
+                // We use this bit to prevent the sending of recursive events for an actor--should an event-listener
+                // do something that would trigger a recursive event.
+                // This is particularly important for the `OnActorClothingUpdate` event, as if an event-listener equips
+                // or unequips armour in response to it: it can easily cause an infinite loop of `TESEquipEvent`s,
+                // which would freeze the game until it crashes from a stack overflow.
+                uint32_t actorChangeEventsAreBeingSent : 1;
+                uint32_t unusedSpareBitsForLaterUse : 11;
+                static_assert(PresetManager::AssignedPresetIndex::BitWidth == 20);
+                uint32_t presetIndex : 20;
+            };
+        };
+
+        static constexpr uint32_t PersistedInCosaveMask = 0b11111111111111111111000000000000;
     };
 
     // We want this structure to be the same size as a FormID so that
@@ -21,6 +31,7 @@ namespace ActorTracker {
 
     // This keeps track of the state which must remain unaffected by the clearing of RaceMenu body-morphs
     // associated with each actor.
+    // We persist some of this state via our SKSE cosave.
     class Registry {
     public:
         static Registry& GetInstance();

--- a/src/ActorTracker/ActorTracker.h
+++ b/src/ActorTracker/ActorTracker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "PresetManager/PresetManager.h"
+#include <boost/unordered/concurrent_flat_map.hpp>
+
+namespace ActorTracker {
+    struct ActorState {
+        // This is set when events are being sent to `IActorChangeEventListener` instances for this actor.
+        // We use this bit to prevent the sending of recursive events for an actor--should an event-listener
+        // do something that would trigger a recursive event.
+        // This is particularly important for the `OnActorClothingUpdate` event, as if an event-listener equips
+        // or unequips armour in response to it: it can easily cause an infinite loop of `TESEquipEvent`s,
+        // which would freeze the game until it crashes from a stack overflow.
+        uint32_t actorChangeEventsAreBeingSent : 1;
+        uint32_t unusedSpareBitsForLaterUse : 31;
+    };
+
+    // We want this structure to be the same size as a FormID so that
+    // storing it in a hashtable with form-IDs is as compact as can be.
+    static_assert(sizeof(ActorState) == 4);
+
+    // This keeps track of the state which must remain unaffected by the clearing of RaceMenu body-morphs
+    // associated with each actor.
+    class Registry {
+    public:
+        static Registry& GetInstance();
+
+        boost::concurrent_flat_map<RE::FormID, ActorState> stateForActor;
+
+    private:
+        static Registry instance;
+    };
+}  // namespace ActorTracker

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -601,4 +601,26 @@ namespace Body {
 
         return std::erase(readinessEventListeners, &eventListener) != 0;
     }
+
+    bool OBody::AttachEventListener(::OBody::API::IActorChangeEventListener& eventListener) {
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        actorChangeEventListeners.push_back(&eventListener);
+
+        return true;
+    }
+
+    bool OBody::DetachEventListener(::OBody::API::IActorChangeEventListener& eventListener) {
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        return std::erase(actorChangeEventListeners, &eventListener) != 0;
+    }
+
+    bool OBody::IsEventListenerAttached(::OBody::API::IActorChangeEventListener& eventListener) {
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        return std::find(actorChangeEventListeners.begin(), actorChangeEventListeners.end(), &eventListener) !=
+               actorChangeEventListeners.end();
+    }
+
 }  // namespace Body

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -540,6 +540,54 @@ namespace Body {
         return Slider{a_morph, a_target - GetMorph(a_actor, a_morph)};
     }
 
+    bool OBody::BecomingReadyForPluginAPIUsage() {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        if (readyForPluginAPIUsage) {
+            return false;
+        }
+
+        for (auto eventListener : readinessEventListeners) {
+            eventListener->OBodyIsBecomingReady();
+        }
+
+        readyForPluginAPIUsage = true;
+
+        return true;
+    }
+
+    void OBody::ReadyForPluginAPIUsage() {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        for (auto eventListener : readinessEventListeners) {
+            eventListener->OBodyIsReady();
+        }
+    }
+
+    bool OBody::BecomingUnreadyForPluginAPIUsage() {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        if (!readyForPluginAPIUsage) {
+            return false;
+        }
+
+        for (auto eventListener : readinessEventListeners) {
+            eventListener->OBodyIsBecomingUnready();
+        }
+
+        return true;
+    }
+
+    void OBody::NoLongerReadyForPluginAPIUsage() {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        readyForPluginAPIUsage = false;
+
+        for (auto eventListener : readinessEventListeners) {
+            eventListener->OBodyIsNoLongerReady();
+        }
+    }
+
     bool OBody::AttachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener) {
         std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
 

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -319,6 +319,16 @@ namespace Body {
         morphInterface->ClearBodyMorphKeys(a_actor, "OBody");
         morphInterface->ClearBodyMorphKeys(a_actor, "OClothe");
         ApplyMorphs(a_actor, true, false);
+
+        using Event = ::OBody::API::IActorChangeEventListener;
+        Event::OnActorMorphsCleared::Payload payload{};
+        Event::OnActorMorphsCleared::Flags flags{};
+
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        for (auto eventListener : actorChangeEventListeners) {
+            eventListener->OnActorMorphsCleared(a_actor, flags, payload);
+        }
     }
 
     void OBody::RemoveClothePreset(RE::Actor* a_actor) const { morphInterface->ClearBodyMorphKeys(a_actor, "OClothe"); }

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -539,4 +539,18 @@ namespace Body {
     Slider OBody::DeriveSlider(RE::Actor* a_actor, const char* a_morph, float a_target) const {
         return Slider{a_morph, a_target - GetMorph(a_actor, a_morph)};
     }
+
+    bool OBody::AttachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener) {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        readinessEventListeners.push_back(&eventListener);
+
+        return true;
+    }
+
+    bool OBody::DetachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener) {
+        std::lock_guard<std::recursive_mutex> lock(readinessListenerLock);
+
+        return std::erase(readinessEventListeners, &eventListener) != 0;
+    }
 }  // namespace Body

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -345,10 +345,11 @@ namespace Body {
         ApplySliderSet(a_actor, set, "OClothe");
     }
 
-    void OBody::ClearActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const {
+    void OBody::ClearActorMorphs(RE::Actor* a_actor, bool updateMorphsWithoutTimer,
+                                 ::OBody::API::IPluginInterface* responsibleInterface) const {
         morphInterface->ClearBodyMorphKeys(a_actor, "OBody");
         morphInterface->ClearBodyMorphKeys(a_actor, "OClothe");
-        ApplyMorphs(a_actor, true, false);
+        ApplyMorphs(a_actor, updateMorphsWithoutTimer, false);
 
         SendActorChangeEvent(
             a_actor,

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -364,6 +364,27 @@ namespace Body {
             });
     }
 
+    void OBody::ReapplyActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const {
+        auto& registry{ActorTracker::Registry::GetInstance()};
+        auto formID = a_actor->formID;
+        uint32_t actorPresetIndex = 0;
+
+        registry.stateForActor.cvisit(formID, [&](auto& entry) { actorPresetIndex = entry.second.presetIndex; });
+
+        if (actorPresetIndex != 0) {
+            // Minus one because an index of zero assigned to the actor signifies the absence of a preset.
+            auto preset = PresetManager::AssignedPresetIndex{actorPresetIndex - 1}.GetPreset(IsFemale(a_actor));
+
+            if (preset != nullptr) {
+                GenerateBodyByPreset(a_actor, *preset, true, responsibleInterface);
+                return;
+            }
+        }
+
+        // No preset is assigned to the actor, we fallback to GenerateActorBody.
+        GenerateActorBody(a_actor, responsibleInterface);
+    }
+
     void OBody::ForcefullyChangeORefit(RE::Actor* a_actor, bool applied,
                                        ::OBody::API::IPluginInterface* responsibleInterface) const {
         applied ? ApplyClothePreset(a_actor) : RemoveClothePreset(a_actor);

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "API/PluginInterface.h"
 #include "PresetManager/PresetManager.h"
 #include "SKEE.h"
 
@@ -61,6 +62,10 @@ namespace Body {
         bool AttachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
         bool DetachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
 
+        bool AttachEventListener(::OBody::API::IActorChangeEventListener& eventListener);
+        bool DetachEventListener(::OBody::API::IActorChangeEventListener& eventListener);
+        bool IsEventListenerAttached(::OBody::API::IActorChangeEventListener& eventListener);
+
         bool readyForPluginAPIUsage = false;
 
         bool synthesisInstalled = false;
@@ -74,6 +79,9 @@ namespace Body {
         std::string distributionKey;
 
         SKEE::IBodyMorphInterface* morphInterface{};
+
+        mutable std::recursive_mutex actorChangeListenerLock;
+        std::vector<::OBody::API::IActorChangeEventListener*> actorChangeEventListeners;
 
         mutable std::recursive_mutex readinessListenerLock;
         std::vector<::OBody::API::IOBodyReadinessEventListener*> readinessEventListeners;

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -53,8 +53,15 @@ namespace Body {
 
         PresetManager::Slider DeriveSlider(RE::Actor* a_actor, const char* a_morph, float a_target) const;
 
+        bool BecomingReadyForPluginAPIUsage();
+        void ReadyForPluginAPIUsage();
+        bool BecomingUnreadyForPluginAPIUsage();
+        void NoLongerReadyForPluginAPIUsage();
+
         bool AttachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
         bool DetachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
+
+        bool readyForPluginAPIUsage = false;
 
         bool synthesisInstalled = false;
 

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -40,6 +40,7 @@ namespace Body {
         void ApplyClothePreset(RE::Actor* a_actor) const;
         void RemoveClothePreset(RE::Actor* a_actor) const;
         void ClearActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
+        void ReapplyActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
 
         void ForcefullyChangeORefit(RE::Actor* a_actor, bool applied,
                                     ::OBody::API::IPluginInterface* responsibleInterface) const;

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -53,6 +53,9 @@ namespace Body {
 
         PresetManager::Slider DeriveSlider(RE::Actor* a_actor, const char* a_morph, float a_target) const;
 
+        bool AttachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
+        bool DetachEventListener(::OBody::API::IOBodyReadinessEventListener& eventListener);
+
         bool synthesisInstalled = false;
 
         bool setRefit = true;
@@ -64,6 +67,9 @@ namespace Body {
         std::string distributionKey;
 
         SKEE::IBodyMorphInterface* morphInterface{};
+
+        mutable std::recursive_mutex readinessListenerLock;
+        std::vector<::OBody::API::IOBodyReadinessEventListener*> readinessEventListeners;
 
     private:
         static OBody instance_;

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -39,7 +39,8 @@ namespace Body {
         void ApplySliderSet(RE::Actor* a_actor, PresetManager::SliderSet& a_sliders, const char* a_key) const;
         void ApplyClothePreset(RE::Actor* a_actor) const;
         void RemoveClothePreset(RE::Actor* a_actor) const;
-        void ClearActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
+        void ClearActorMorphs(RE::Actor* a_actor, bool updateMorphsWithoutTimer,
+                              ::OBody::API::IPluginInterface* responsibleInterface) const;
         void ReapplyActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
 
         void ForcefullyChangeORefit(RE::Actor* a_actor, bool applied,

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -28,17 +28,18 @@ namespace Body {
 
         void ProcessActorEquipEvent(RE::Actor* a_actor, bool a_removingArmor, const RE::TESForm* a_equippedArmor) const;
 
-        void GenerateActorBody(RE::Actor* a_actor) const;
-        void GenerateBodyByName(RE::Actor* a_actor, const std::string& a_name) const;
-        void GenerateBodyByPreset(RE::Actor* a_actor, PresetManager::Preset& a_preset,
-                                  bool updateMorphsWithoutTimer) const;
+        void GenerateActorBody(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
+        void GenerateBodyByName(RE::Actor* a_actor, const std::string& a_name,
+                                ::OBody::API::IPluginInterface* responsibleInterface) const;
+        void GenerateBodyByPreset(RE::Actor* a_actor, PresetManager::Preset& a_preset, bool updateMorphsWithoutTimer,
+                                  ::OBody::API::IPluginInterface* responsibleInterface) const;
 
         void ApplySlider(RE::Actor* a_actor, const PresetManager::Slider& a_slider, const char* a_key,
                          float a_weight) const;
         void ApplySliderSet(RE::Actor* a_actor, PresetManager::SliderSet& a_sliders, const char* a_key) const;
         void ApplyClothePreset(RE::Actor* a_actor) const;
         void RemoveClothePreset(RE::Actor* a_actor) const;
-        void ClearActorMorphs(RE::Actor* a_actor) const;
+        void ClearActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
 
         static float GetWeight(RE::Actor* a_actor);
 
@@ -122,6 +123,10 @@ namespace Body {
 
         mutable std::recursive_mutex readinessListenerLock;
         std::vector<::OBody::API::IOBodyReadinessEventListener*> readinessEventListeners;
+
+        // This `IPluginInterface` instance is a special one used to signal to plugin-API event-listeners
+        // that a change was effected by OBody's Papyrus functions (the OBodyNative script).
+        mutable ::OBody::API::PluginInterface specialPapyrusPluginInterface{"_Papyrus"};
 
     private:
         static OBody instance_;

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -41,6 +41,9 @@ namespace Body {
         void RemoveClothePreset(RE::Actor* a_actor) const;
         void ClearActorMorphs(RE::Actor* a_actor, ::OBody::API::IPluginInterface* responsibleInterface) const;
 
+        void ForcefullyChangeORefit(RE::Actor* a_actor, bool applied,
+                                    ::OBody::API::IPluginInterface* responsibleInterface) const;
+
         static float GetWeight(RE::Actor* a_actor);
 
         bool IsClotheActive(RE::Actor* a_actor) const;

--- a/src/Body/Event.cpp
+++ b/src/Body/Event.cpp
@@ -19,7 +19,7 @@ RE::BSEventNotifyControl Event::OBodyEventHandler::ProcessEvent(const RE::TESIni
 
     if (RE::Actor * actor{a_event->objectInitialized->As<RE::Actor>()};
         (actor != nullptr) && actor->HasKeywordString("ActorTypeNPC") && !actor->IsChild()) {
-        Body::OBody::GetInstance().GenerateActorBody(actor);
+        Body::OBody::GetInstance().GenerateActorBody(actor, nullptr);
     }
 
     return RE::BSEventNotifyControl::kContinue;

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -8,7 +8,10 @@
 #include "Papyrus/PapyrusBody.h"
 
 namespace PapyrusBody {
-    void GenActor(RE::StaticFunctionTag*, RE::Actor* a_actor) { Body::OBody::GetInstance().GenerateActorBody(a_actor); }
+    void GenActor(RE::StaticFunctionTag*, RE::Actor* a_actor) {
+        const auto& obody{Body::OBody::GetInstance()};
+        obody.GenerateActorBody(a_actor, &obody.specialPapyrusPluginInterface);
+    }
 
     void SetORefit(RE::StaticFunctionTag*, const bool a_enabled) { Body::OBody::GetInstance().setRefit = a_enabled; }
 
@@ -57,7 +60,8 @@ namespace PapyrusBody {
     // ReSharper disable once CppPassValueParameterByConstReference
     void ApplyPresetByName(RE::StaticFunctionTag*, RE::Actor* a_actor,
                            const std::string a_name) {  // NOLINT(*-unnecessary-value-param)
-        Body::OBody::GetInstance().GenerateBodyByName(a_actor, a_name);
+        const auto& obody{Body::OBody::GetInstance()};
+        obody.GenerateBodyByName(a_actor, a_name, &obody.specialPapyrusPluginInterface);
     }
 
     // The trailing underscore is there because the `RemoveClothesOverlay` defined
@@ -108,7 +112,8 @@ namespace PapyrusBody {
     }
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {
-        Body::OBody::GetInstance().ClearActorMorphs(a_actor);
+        const auto& obody{Body::OBody::GetInstance()};
+        obody.ClearActorMorphs(a_actor, &obody.specialPapyrusPluginInterface);
     }
 
     bool presetNameComparison(const std::string_view a, const std::string_view b) {

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -68,18 +68,21 @@ namespace PapyrusBody {
         obody.RemoveClothePreset(a_actor);
         obody.ApplyMorphs(a_actor, true);
 
-        using Event = ::OBody::API::IActorChangeEventListener;
-        Event::OnORefitForcefullyChanged::Payload payload{};
+        obody.SendActorChangeEvent(
+            a_actor,
+            [&] {
+                using Event = ::OBody::API::IActorChangeEventListener;
+                Event::OnORefitForcefullyChanged::Payload payload{};
 
-        Event::OnORefitForcefullyChanged::Flags flags{};
-        static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
-        flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
+                Event::OnORefitForcefullyChanged::Flags flags{};
+                static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
+                flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
 
-        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
-
-        for (auto eventListener : obody.actorChangeEventListeners) {
-            eventListener->OnORefitForcefullyChanged(a_actor, flags, payload);
-        }
+                return std::make_pair(flags, payload);
+            },
+            [](auto listener, auto actor, auto&& args) {
+                listener->OnORefitForcefullyChanged(actor, args.first, args.second);
+            });
     }
 
     void AddClothesOverlay(RE::StaticFunctionTag*, RE::Actor* a_actor) {
@@ -87,18 +90,21 @@ namespace PapyrusBody {
         obody.ApplyClothePreset(a_actor);
         obody.ApplyMorphs(a_actor, true);
 
-        using Event = ::OBody::API::IActorChangeEventListener;
-        Event::OnORefitForcefullyChanged::Payload payload{};
+        obody.SendActorChangeEvent(
+            a_actor,
+            [&] {
+                using Event = ::OBody::API::IActorChangeEventListener;
+                Event::OnORefitForcefullyChanged::Payload payload{};
 
-        Event::OnORefitForcefullyChanged::Flags flags{Event::OnORefitForcefullyChanged::Flags::IsORefitApplied};
-        static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
-        flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
+                Event::OnORefitForcefullyChanged::Flags flags{Event::OnORefitForcefullyChanged::Flags::IsORefitApplied};
+                static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
+                flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
 
-        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
-
-        for (auto eventListener : obody.actorChangeEventListeners) {
-            eventListener->OnORefitForcefullyChanged(a_actor, flags, payload);
-        }
+                return std::make_pair(flags, payload);
+            },
+            [](auto listener, auto actor, auto&& args) {
+                listener->OnORefitForcefullyChanged(actor, args.first, args.second);
+            });
     }
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -67,12 +67,38 @@ namespace PapyrusBody {
         const auto& obody{Body::OBody::GetInstance()};
         obody.RemoveClothePreset(a_actor);
         obody.ApplyMorphs(a_actor, true);
+
+        using Event = ::OBody::API::IActorChangeEventListener;
+        Event::OnORefitForcefullyChanged::Payload payload{};
+
+        Event::OnORefitForcefullyChanged::Flags flags{};
+        static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
+        flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
+
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        for (auto eventListener : obody.actorChangeEventListeners) {
+            eventListener->OnORefitForcefullyChanged(a_actor, flags, payload);
+        }
     }
 
     void AddClothesOverlay(RE::StaticFunctionTag*, RE::Actor* a_actor) {
         const auto& obody{Body::OBody::GetInstance()};
         obody.ApplyClothePreset(a_actor);
         obody.ApplyMorphs(a_actor, true);
+
+        using Event = ::OBody::API::IActorChangeEventListener;
+        Event::OnORefitForcefullyChanged::Payload payload{};
+
+        Event::OnORefitForcefullyChanged::Flags flags{Event::OnORefitForcefullyChanged::Flags::IsORefitApplied};
+        static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
+        flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
+
+        std::lock_guard<std::recursive_mutex> lock(actorChangeListenerLock);
+
+        for (auto eventListener : obody.actorChangeEventListeners) {
+            eventListener->OnORefitForcefullyChanged(a_actor, flags, payload);
+        }
     }
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -69,46 +69,12 @@ namespace PapyrusBody {
     // pre-existing scripts, so now it forwards to the native `RemoveClothesOverlay_`.
     void RemoveClothesOverlay_(RE::StaticFunctionTag*, RE::Actor* a_actor) {
         const auto& obody{Body::OBody::GetInstance()};
-        obody.RemoveClothePreset(a_actor);
-        obody.ApplyMorphs(a_actor, true);
-
-        obody.SendActorChangeEvent(
-            a_actor,
-            [&] {
-                using Event = ::OBody::API::IActorChangeEventListener;
-                Event::OnORefitForcefullyChanged::Payload payload{};
-
-                Event::OnORefitForcefullyChanged::Flags flags{};
-                static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
-                flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
-
-                return std::make_pair(flags, payload);
-            },
-            [](auto listener, auto actor, auto&& args) {
-                listener->OnORefitForcefullyChanged(actor, args.first, args.second);
-            });
+        obody.ForcefullyChangeORefit(a_actor, false, &obody.specialPapyrusPluginInterface);
     }
 
     void AddClothesOverlay(RE::StaticFunctionTag*, RE::Actor* a_actor) {
         const auto& obody{Body::OBody::GetInstance()};
-        obody.ApplyClothePreset(a_actor);
-        obody.ApplyMorphs(a_actor, true);
-
-        obody.SendActorChangeEvent(
-            a_actor,
-            [&] {
-                using Event = ::OBody::API::IActorChangeEventListener;
-                Event::OnORefitForcefullyChanged::Payload payload{};
-
-                Event::OnORefitForcefullyChanged::Flags flags{Event::OnORefitForcefullyChanged::Flags::IsORefitApplied};
-                static_assert(Event::OnORefitForcefullyChanged::Flags::IsORefitEnabled == (1 << 2));
-                flags = static_cast<Event::OnORefitForcefullyChanged::Flags>(flags | (uint64_t(obody.setRefit) << 2));
-
-                return std::make_pair(flags, payload);
-            },
-            [](auto listener, auto actor, auto&& args) {
-                listener->OnORefitForcefullyChanged(actor, args.first, args.second);
-            });
+        obody.ForcefullyChangeORefit(a_actor, true, &obody.specialPapyrusPluginInterface);
     }
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -82,6 +82,11 @@ namespace PapyrusBody {
         obody.ClearActorMorphs(a_actor, true, &obody.specialPapyrusPluginInterface);
     }
 
+    void ReapplyActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {
+        const auto& obody{Body::OBody::GetInstance()};
+        obody.ReapplyActorMorphs(a_actor, &obody.specialPapyrusPluginInterface);
+    }
+
     bool presetNameComparison(const std::string_view a, const std::string_view b) {
         return boost::algorithm::ilexicographical_compare(a, b);
     }
@@ -132,6 +137,7 @@ namespace PapyrusBody {
         OBODY_PAPYRUS_BIND(GetFemaleDatabaseSize);
         OBODY_PAPYRUS_BIND(GetMaleDatabaseSize);
         OBODY_PAPYRUS_BIND(ResetActorOBodyMorphs);
+        OBODY_PAPYRUS_BIND(ReapplyActorOBodyMorphs);
 
         OBODY_PAPYRUS_BIND(SetORefit);
         OBODY_PAPYRUS_BIND(SetNippleSlidersORefitEnabled);

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -60,6 +60,15 @@ namespace PapyrusBody {
         Body::OBody::GetInstance().GenerateBodyByName(a_actor, a_name);
     }
 
+    // The trailing underscore is there because the `RemoveClothesOverlay` defined
+    // in the Papyrus script is non-native, and making it native could have broken
+    // pre-existing scripts, so now it forwards to the native `RemoveClothesOverlay_`.
+    void RemoveClothesOverlay_(RE::StaticFunctionTag*, RE::Actor* a_actor) {
+        const auto& obody{Body::OBody::GetInstance()};
+        obody.RemoveClothePreset(a_actor);
+        obody.ApplyMorphs(a_actor, true);
+    }
+
     void AddClothesOverlay(RE::StaticFunctionTag*, RE::Actor* a_actor) {
         const auto& obody{Body::OBody::GetInstance()};
         obody.ApplyClothePreset(a_actor);
@@ -112,6 +121,7 @@ namespace PapyrusBody {
         OBODY_PAPYRUS_BIND(GenActor);
         OBODY_PAPYRUS_BIND(ApplyPresetByName);
         OBODY_PAPYRUS_BIND(GetAllPossiblePresets);
+        OBODY_PAPYRUS_BIND(RemoveClothesOverlay_);
         OBODY_PAPYRUS_BIND(AddClothesOverlay);
         OBODY_PAPYRUS_BIND(RegisterForOBodyEvent);
         OBODY_PAPYRUS_BIND(RegisterForOBodyNakedEvent);

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -121,6 +121,26 @@ namespace PapyrusBody {
         return ret;
     }
 
+    std::string GetPresetAssignedToActor(RE::StaticFunctionTag*, RE::Actor* a_actor) {
+        auto& registry{ActorTracker::Registry::GetInstance()};
+        auto formID = a_actor->formID;
+        uint32_t actorPresetIndex = 0;
+
+        registry.stateForActor.cvisit(formID, [&](auto& entry) { actorPresetIndex = entry.second.presetIndex; });
+
+        if (actorPresetIndex != 0) {
+            // Minus one because an index of zero assigned to the actor signifies the absence of a preset.
+            auto preset =
+                PresetManager::AssignedPresetIndex{actorPresetIndex - 1}.GetPreset(Body::OBody::IsFemale(a_actor));
+
+            if (preset != nullptr) {
+                return preset->name;
+            }
+        }
+
+        return "";
+    }
+
     bool Bind(VM* a_vm) {
         constexpr auto obj = "OBodyNative"sv;
 
@@ -138,6 +158,7 @@ namespace PapyrusBody {
         OBODY_PAPYRUS_BIND(GetMaleDatabaseSize);
         OBODY_PAPYRUS_BIND(ResetActorOBodyMorphs);
         OBODY_PAPYRUS_BIND(ReapplyActorOBodyMorphs);
+        OBODY_PAPYRUS_BIND(GetPresetAssignedToActor);
 
         OBODY_PAPYRUS_BIND(SetORefit);
         OBODY_PAPYRUS_BIND(SetNippleSlidersORefitEnabled);

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -149,20 +149,48 @@ namespace PapyrusBody {
 
         if (a_presetName.size() == 0) {
             // Clear their preset assignment, if they have one.
-            registry.stateForActor.visit(formID, [&](auto& entry) { entry.second.presetIndex = 0; });
+            uint32_t previousPresetIndex = 0;
+            registry.stateForActor.visit(formID, [&](auto& entry) {
+                previousPresetIndex = entry.second.presetIndex;
+                entry.second.presetIndex = 0;
+            });
 
             if (!a_doNotApplyMorphs) {
                 obody.ClearActorMorphs(a_actor, a_forceImmediateApplicationOfMorphs,
                                        &obody.specialPapyrusPluginInterface);
             }
 
+            if (previousPresetIndex != 0) {
+                obody.SendActorChangeEvent(
+                    a_actor,
+                    [&] {
+                        using Event = ::OBody::API::IActorChangeEventListener;
+
+                        Event::OnActorPresetChangedWithoutGeneration::Payload payload{
+                            &obody.specialPapyrusPluginInterface,
+                            // Note that the plugin-API mandates that this be a null-terminated string.
+                            // Minus one because an index of zero assigned to the actor signifies the absence of a
+                            // preset.
+                            PresetManager::AssignedPresetIndex{previousPresetIndex - 1}.GetPresetNameView(
+                                obody.IsFemale(a_actor))};
+
+                        auto flags = Event::OnActorPresetChangedWithoutGeneration::Flags::PresetWasUnassigned;
+
+                        return std::make_pair(flags, payload);
+                    },
+                    [](auto listener, auto actor, auto&& args) {
+                        listener->OnActorPresetChangedWithoutGeneration(actor, args.first, args.second);
+                    });
+            }
+
             return true;
         }
 
+        bool isFemale = Body::OBody::IsFemale(a_actor);
+
         const auto& presetContainer{PresetManager::PresetContainer::GetInstance()};
         auto preset = GetPresetByNameForRandom(
-            Body::OBody::IsFemale(a_actor) ? presetContainer.allFemalePresets : presetContainer.allMalePresets,
-            a_presetName);
+            isFemale ? presetContainer.allFemalePresets : presetContainer.allMalePresets, a_presetName);
 
         if (!preset) {
             return false;
@@ -178,13 +206,32 @@ namespace PapyrusBody {
                                        &obody.specialPapyrusPluginInterface);
         } else {
             // Assign the preset to the actor.
+            auto assignedPresetIndex = preset->assignedIndex;
             // Plus one because an index of zero on the actor signifies the absence of a preset.
-            uint32_t actorPresetIndex = preset->assignedIndex.value + 1;
+            uint32_t actorPresetIndex = assignedPresetIndex.value + 1;
             ActorTracker::ActorState fallbackActorState{};
             fallbackActorState.presetIndex = actorPresetIndex;
 
             registry.stateForActor.emplace_or_visit(formID, fallbackActorState,
                                                     [&](auto& entry) { entry.second.presetIndex = actorPresetIndex; });
+
+            obody.SendActorChangeEvent(
+                a_actor,
+                [&] {
+                    using Event = ::OBody::API::IActorChangeEventListener;
+
+                    Event::OnActorPresetChangedWithoutGeneration::Payload payload{
+                        &obody.specialPapyrusPluginInterface,
+                        // Note that the plugin-API mandates that this be a null-terminated string.
+                        assignedPresetIndex.GetPresetNameView(isFemale)};
+
+                    Event::OnActorPresetChangedWithoutGeneration::Flags flags{};
+
+                    return std::make_pair(flags, payload);
+                },
+                [](auto listener, auto actor, auto&& args) {
+                    listener->OnActorPresetChangedWithoutGeneration(actor, args.first, args.second);
+                });
         }
 
         return true;

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -79,7 +79,7 @@ namespace PapyrusBody {
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor) {
         const auto& obody{Body::OBody::GetInstance()};
-        obody.ClearActorMorphs(a_actor, &obody.specialPapyrusPluginInterface);
+        obody.ClearActorMorphs(a_actor, true, &obody.specialPapyrusPluginInterface);
     }
 
     bool presetNameComparison(const std::string_view a, const std::string_view b) {

--- a/src/Papyrus/PapyrusBody.h
+++ b/src/Papyrus/PapyrusBody.h
@@ -39,5 +39,8 @@ namespace PapyrusBody {
 
     std::string GetPresetAssignedToActor(RE::StaticFunctionTag*, RE::Actor* a_actor);
 
+    bool AssignPresetToActor(RE::StaticFunctionTag*, RE::Actor* a_actor, const std::string a_presetName,
+                             bool a_forceImmediateApplicationOfMorphs, bool a_doNotApplyMorphs);
+
     bool Bind(VM* a_vm);
 }  // namespace PapyrusBody

--- a/src/Papyrus/PapyrusBody.h
+++ b/src/Papyrus/PapyrusBody.h
@@ -37,5 +37,7 @@ namespace PapyrusBody {
 
     std::vector<std::string> GetAllPossiblePresets(RE::StaticFunctionTag*, RE::Actor* a_actor);
 
+    std::string GetPresetAssignedToActor(RE::StaticFunctionTag*, RE::Actor* a_actor);
+
     bool Bind(VM* a_vm);
 }  // namespace PapyrusBody

--- a/src/Papyrus/PapyrusBody.h
+++ b/src/Papyrus/PapyrusBody.h
@@ -33,6 +33,8 @@ namespace PapyrusBody {
 
     void ResetActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor);
 
+    void ReapplyActorOBodyMorphs(RE::StaticFunctionTag*, RE::Actor* a_actor);
+
     std::vector<std::string> GetAllPossiblePresets(RE::StaticFunctionTag*, RE::Actor* a_actor);
 
     bool Bind(VM* a_vm);

--- a/src/PresetManager/PresetManager.cpp
+++ b/src/PresetManager/PresetManager.cpp
@@ -120,6 +120,37 @@ namespace PresetManager {
         logger::info("Assigned indexes to all the loaded presets.");
     }
 
+    Preset* AssignedPresetIndex::GetPreset(bool actorIsFemale) const {
+        auto& presetContainer{PresetContainer::GetInstance()};
+
+        const auto& sparseMap =
+            actorIsFemale ? presetContainer.allFemalePresetsByIndex : presetContainer.allMalePresetsByIndex;
+
+        // If the actor's sex has not changed, then this index must be in bounds, but an actor's sex may have changed.
+        if (value >= sparseMap.size()) {
+            return nullptr;
+        }
+
+        auto denseIndex = sparseMap[value];
+        auto& presets = actorIsFemale ? presetContainer.allFemalePresets : presetContainer.allMalePresets;
+
+        // The user may have removed this preset since it was assigned,
+        // if they did the sparse-map will have mapped it to -1.
+        assert(denseIndex < presets.size() || denseIndex == -1);
+
+        return denseIndex < presets.size() ? &presets[denseIndex] : nullptr;
+    }
+
+    std::string_view AssignedPresetIndex::GetPresetNameView(bool actorIsFemale) const {
+        const auto preset = GetPreset(actorIsFemale);
+
+        if (preset != nullptr) {
+            return {preset->name.data(), preset->name.size()};
+        }
+
+        return {};
+    }
+
     Preset GetPresetByName(const PresetSet& a_presetSet, const std::string_view a_name, const bool female) {
         logger::info("Looking for preset: {}", a_name);
 

--- a/src/PresetManager/PresetManager.h
+++ b/src/PresetManager/PresetManager.h
@@ -24,6 +24,41 @@ namespace PresetManager {
 
     using SliderSet = boost::unordered_flat_map<std::string, Slider>;
 
+    // We can refer to presets by their index rather than their name.
+    // We do this to reduce the memory usage for keeping track of which preset is assigned to each actor--
+    // the memory footprint isn't a concern while the game is running, instead it's a concern for the
+    // game's save files: the bigger the state for tracking preset assignment is, the bigger save files are,
+    // and thus the longer it takes to save and load a game--not good for the players.
+    //
+    // As a bonus: integers are much easier to handle atomically than strings,
+    // making thread-safety much more easily (and performantly) achievable.
+    //
+    // There is, as always, a downside however, to be able to refer to presets by index
+    // we need to assign an index to each preset, and we need to keep that index consistent
+    // between game saves and loads, even if the player installs or removes presets mid-game.
+    // The way we do this is relatively simple: the first time we encounter a preset, we assign it an index.
+    // When we save the game, we store to our SKSE cosave the preset index assignments,
+    // and when we load the game we read them back from our SKSE cosave.
+    //
+    // The indexes we assign to preset names simply increment by one with each new preset name.
+    // Each index is a 20-bit value, so we simply don't worry about running out of indexes.
+    //
+    // Note that because we keep preset indexes stable even if a player removes a preset, the preset indexes
+    // are thus sparse when it comes to accessing a contiguous sequence of usable presets.
+    //
+    // We keep the preset indexes stable for removed presets so as to gracefully handle the event of a player
+    // accidentally removing a preset and not realising until after they've played for a bit and saved a few times.
+    // It would make for a poor UX if we clobbered their preset assignment in that scenario.
+    struct AssignedPresetIndex {
+        // This permits a player to have 1,048,576 BodySlide presets, per sex, active at a time.
+        // That should be enough, surely?
+        static constexpr uint32_t BitWidth = 20;
+
+        uint32_t value = 0;
+    };
+
+    using SparsePresetIndex = uint32_t;
+
     struct Preset {
         Preset() = default;
         explicit Preset(const char* a_name) : name(a_name) {}
@@ -34,9 +69,11 @@ namespace PresetManager {
         std::string name;
         std::string body;
         SliderSet sliders;
+        AssignedPresetIndex assignedIndex;
     };
 
     using PresetSet = std::vector<Preset>;
+    using SparsePresetMapping = std::vector<SparsePresetIndex>;
 
     class PresetContainer {
     public:
@@ -56,6 +93,22 @@ namespace PresetManager {
 
         PresetSet allFemalePresets;
         PresetSet allMalePresets;
+
+        /* These map a sparse preset index to the dense storage of the presets proper.
+           A value of -1 is used to signify the absence of a preset.
+           If you're thinking that a hashtable may be more appropriate for this than an array,
+           consider that we expect this be very dense, so dense that using a hashtable would
+           likely use more memory in exchange for more expensive lookups. */
+        SparsePresetMapping allFemalePresetsByIndex;
+        SparsePresetMapping allMalePresetsByIndex;
+        /* These maps are intended for preset index assignment,
+           not general lookups, which are generally case-insensitive. */
+        boost::unordered_flat_map<std::string, AssignedPresetIndex> femalePresetIndexByName;
+        boost::unordered_flat_map<std::string, AssignedPresetIndex> malePresetIndexByName;
+        AssignedPresetIndex nextFemalePresetIndex;
+        AssignedPresetIndex nextMalePresetIndex;
+
+        void AssignPresetIndexes();
 
         static PresetContainer& GetInstance();
 

--- a/src/PresetManager/PresetManager.h
+++ b/src/PresetManager/PresetManager.h
@@ -24,6 +24,8 @@ namespace PresetManager {
 
     using SliderSet = boost::unordered_flat_map<std::string, Slider>;
 
+    struct Preset;
+
     // We can refer to presets by their index rather than their name.
     // We do this to reduce the memory usage for keeping track of which preset is assigned to each actor--
     // the memory footprint isn't a concern while the game is running, instead it's a concern for the
@@ -55,6 +57,9 @@ namespace PresetManager {
         static constexpr uint32_t BitWidth = 20;
 
         uint32_t value = 0;
+
+        Preset* GetPreset(bool actorIsFemale) const;
+        std::string_view GetPresetNameView(bool actorIsFemale) const;
     };
 
     using SparsePresetIndex = uint32_t;

--- a/src/PresetManager/PresetManager.h
+++ b/src/PresetManager/PresetManager.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <boost/unordered/unordered_flat_map.hpp>
+
 namespace PresetManager {
     enum class BodyType { CBBE, UNP };
 
@@ -20,7 +22,7 @@ namespace PresetManager {
         float max = 0.f;
     };
 
-    using SliderSet = std::unordered_map<std::string, Slider>;
+    using SliderSet = boost::unordered_flat_map<std::string, Slider>;
 
     struct Preset {
         Preset() = default;

--- a/src/SaveFileState/SaveFileState.cpp
+++ b/src/SaveFileState/SaveFileState.cpp
@@ -1,0 +1,277 @@
+#include "SaveFileState/SaveFileState.h"
+
+namespace SaveFileState {
+    // Refer to https://github.com/Ryan-rsm-McKenzie/CommonLibSSE/wiki/Serialization
+
+    void SaveState(SKSE::SerializationInterface* save) {
+        Buffer buffer;
+
+        if (save->OpenRecord(PresetNameIndexMapTypeID, 0)) {
+            if (!WriteRecordDataForPresetNameIndexMapV0(save, buffer, PresetManager::PresetContainer::GetInstance())) {
+                logger::critical("Failed to save the preset-name-index-map!");
+            }
+        } else {
+            logger::critical("Failed to open a record for the preset-name-index-map!");
+        }
+    }
+
+    void LoadState(SKSE::SerializationInterface* load) {
+        Buffer buffer;
+
+        size_t presetNameMapCount = 0;
+
+        uint32_t type;
+        uint32_t version;
+        uint32_t length;
+
+        while (load->GetNextRecordInfo(type, version, length)) {
+            switch (type) {
+                case PresetNameIndexMapTypeID: {
+                    switch (version) {
+                        case 0: {
+                            if (++presetNameMapCount == 1) {
+                                if (!ReadRecordDataForPresetNameIndexMapV0(
+                                        load, buffer, PresetManager::PresetContainer::GetInstance())) {
+                                    logger::critical("Failed to load the preset-name-index-map!");
+                                }
+                            }
+                            break;
+                        }
+                        default: {
+                            logger::error(
+                                "A preset-name-index-map record of an unknown version '{}' was found in the cosave.",
+                                version);
+                            break;
+                        }
+                    }
+                    break;
+                }
+                default: {
+                    logger::error("A record of unknown type {:#010x} was found in the cosave.", type);
+                    break;
+                }
+            }
+        }
+
+        if (presetNameMapCount > 1) {
+            logger::error(
+                "Multiple preset-name-index-map records were found in the cosave. Only the first one was read.");
+        }
+    }
+
+    // In this context, revert means to undo the effects of a call to LoadState.
+    void RevertState(SKSE::SerializationInterface* revert) {
+        auto& presetContainer = PresetManager::PresetContainer::GetInstance();
+        presetContainer.femalePresetIndexByName.clear();
+        presetContainer.malePresetIndexByName.clear();
+        presetContainer.nextFemalePresetIndex.value = 0;
+        presetContainer.nextMalePresetIndex.value = 0;
+    }
+
+    bool WriteRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* save, Buffer buffer,
+                                                const PresetManager::PresetContainer& presetContainer) {
+        size_t offset = 0;
+
+        auto write = [&](const auto& indexByNameMap, auto nextPresetIndex) -> bool {
+            // The format for this is dead simple:
+            // For all female presets, and then all male presets,
+            // we begin with a fixed-sized header,
+            // and then for each preset we know, we store the length of its name as a 4-byte integer,
+            // followed by a struct detailing its index and other pertinent information,
+            // and then the contents of its name.
+            // We terminate the preset names with a length of 0, which is not followed by anything.
+            static_assert(alignof(PresetNameIndexMapHeaderV0) >= alignof(PresetNameLength));
+            static_assert(alignof(PresetNameLength) >= alignof(StateForPresetNameV0));
+
+            PresetNameIndexMapHeaderV0 header;
+            PresetNameLength terminatingLength;
+
+            assert(IsAlignedTo(offset, alignof(PresetNameIndexMapHeaderV0)));
+
+            if (offset >= BufferSize - sizeof(PresetNameIndexMapHeaderV0)) {
+                if (!save->WriteRecordData(buffer, offset)) goto failedToWriteRecordData;
+                offset = 0;
+            }
+
+            header = {nextPresetIndex.value};
+            std::memcpy(&buffer[offset], &header, sizeof(decltype(header)));
+            offset += sizeof(decltype(header));
+
+            for (const auto& [name, index] : indexByNameMap) {
+                assert(IsAlignedTo(offset, alignof(PresetNameLength)));
+
+                assert(name.size() <= std::numeric_limits<PresetNameLength>::max());
+
+                PresetNameLength remainingNameBytes = static_cast<PresetNameLength>(name.size());
+                PresetNameLength nameOffset = 0;
+
+                if (offset >= BufferSize - sizeof(PresetNameLength) - sizeof(StateForPresetNameV0)) {
+                    if (!save->WriteRecordData(buffer, offset)) goto failedToWriteRecordData;
+                    offset = 0;
+                }
+
+                assert(offset <= BufferSize - sizeof(PresetNameLength) - sizeof(StateForPresetNameV0));
+                std::memcpy(&buffer[offset], &remainingNameBytes, sizeof(decltype(remainingNameBytes)));
+                offset += sizeof(decltype(remainingNameBytes));
+
+                StateForPresetNameV0 presetNameState{};
+                presetNameState.presetIndex = index.value;
+
+                std::memcpy(&buffer[offset], &presetNameState, sizeof(decltype(presetNameState)));
+                offset += sizeof(decltype(presetNameState));
+
+                for (;;) {
+                    size_t bytesToWrite =
+                        std::min(remainingNameBytes, static_cast<PresetNameLength>(BufferSize - offset));
+                    remainingNameBytes -= bytesToWrite;
+
+                    std::memcpy(&buffer[offset], name.data() + nameOffset, bytesToWrite);
+                    offset += bytesToWrite;
+
+                    assert(offset <= BufferSize);
+                    if (offset == BufferSize) {
+                        if (!save->WriteRecordData(buffer, BufferSize)) goto failedToWriteRecordData;
+                        nameOffset += bytesToWrite;
+                        offset = 0;
+                        continue;
+                    }
+
+                    assert(remainingNameBytes == 0);
+
+                    break;
+                }
+
+                offset = AlignUpTo(offset, alignof(PresetNameLength));
+            }
+
+            assert(offset <= BufferSize);
+            if (offset >= BufferSize - sizeof(PresetNameLength)) {
+                if (!save->WriteRecordData(buffer, offset)) goto failedToWriteRecordData;
+                offset = 0;
+            }
+
+            terminatingLength = 0;
+            std::memcpy(&buffer[offset], &terminatingLength, sizeof(decltype(terminatingLength)));
+            offset += sizeof(decltype(terminatingLength));
+
+            return true;
+        failedToWriteRecordData:
+            logger::critical("Failed to write to the open record's data.");
+            return false;
+        };
+
+        if (!write(presetContainer.femalePresetIndexByName, presetContainer.nextFemalePresetIndex)) return false;
+        if (!write(presetContainer.malePresetIndexByName, presetContainer.nextMalePresetIndex)) return false;
+
+        // Flush any remaining data.
+        if (!save->WriteRecordData(buffer, offset)) return false;
+
+        return true;
+    }
+
+    bool ReadRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* load, Buffer buffer,
+                                               PresetManager::PresetContainer& presetContainer) {
+        size_t offset = 0;
+        size_t remainingBytes = 0;
+
+        auto getMoreBytes = [&]() -> bool {
+            if (remainingBytes == 0) {
+                remainingBytes = load->ReadRecordData(buffer, BufferSize);
+
+                if (remainingBytes == 0) return false;
+
+                if (!IsAlignedTo(remainingBytes, alignof(PresetNameIndexMapHeaderV0))) {
+                    logger::critical("This save file's preset-name-index-map is misaligned! {{remainingBytes: {}}}",
+                                     remainingBytes);
+                    return false;
+                }
+
+                offset = 0;
+            }
+
+            return true;
+        };
+
+        auto read = [&](auto& indexByNameMap, auto& nextPresetIndex) -> bool {
+            // See `WriteRecordDataForPresetNameIndexMapV0` for a description of this format.
+            if (!getMoreBytes()) goto prematurelyTerminated;
+            if (remainingBytes < sizeof(PresetNameIndexMapHeaderV0)) goto prematurelyTerminated;
+
+            PresetNameIndexMapHeaderV0 header;
+            std::memcpy(&header, &buffer[offset], sizeof(decltype(header)));
+            offset += sizeof(decltype(header));
+            remainingBytes -= sizeof(decltype(header));
+
+            nextPresetIndex.value = header.nextPresetIndex;
+
+            indexByNameMap.reserve(nextPresetIndex.value);
+
+            for (;;) {
+                if (!getMoreBytes()) goto prematurelyTerminated;
+                if (remainingBytes < sizeof(PresetNameLength)) goto prematurelyTerminated;
+
+                PresetNameLength length;
+                std::memcpy(&length, &buffer[offset], sizeof(decltype(length)));
+                offset += sizeof(decltype(length));
+                remainingBytes -= sizeof(decltype(length));
+
+                if (length == 0) {
+                    break;
+                }
+
+                if (!getMoreBytes()) goto prematurelyTerminated;
+                if (remainingBytes < sizeof(StateForPresetNameV0)) goto prematurelyTerminated;
+
+                StateForPresetNameV0 presetNameState;
+                std::memcpy(&presetNameState, &buffer[offset], sizeof(decltype(presetNameState)));
+                offset += sizeof(decltype(presetNameState));
+                remainingBytes -= sizeof(decltype(presetNameState));
+
+                std::string presetName;
+                presetName.reserve(length);
+
+                PresetNameLength remainingNameBytes = length;
+
+                for (;;) {
+                    size_t bytesToRead = std::min(remainingNameBytes, static_cast<PresetNameLength>(remainingBytes));
+                    remainingNameBytes -= bytesToRead;
+
+                    presetName.append(reinterpret_cast<const char*>(&buffer[offset]), bytesToRead);
+                    offset += bytesToRead;
+                    remainingBytes -= bytesToRead;
+
+                    if (remainingNameBytes == 0) {
+                        break;
+                    }
+
+                    if (!getMoreBytes()) goto prematurelyTerminated;
+                }
+
+                assert(presetName.size() == length);
+
+                size_t unalignedOffset = offset;
+                offset = AlignUpTo(offset, alignof(PresetNameLength));
+                remainingBytes -= offset - unalignedOffset;
+
+                indexByNameMap[presetName] = PresetManager::AssignedPresetIndex{presetNameState.presetIndex};
+            }
+
+            return true;
+        prematurelyTerminated:
+            logger::critical("This save file's preset-name-index-map was prematurely terminated!");
+            return false;
+        };
+
+        if (!read(presetContainer.femalePresetIndexByName, presetContainer.nextFemalePresetIndex)) return false;
+        if (!read(presetContainer.malePresetIndexByName, presetContainer.nextMalePresetIndex)) return false;
+
+        if (remainingBytes != 0) {
+            logger::error(
+                "This save file's preset-name-index-map contains unknown trailing data which has been ignored. "
+                "{{remainingBytes: {}}}",
+                remainingBytes);
+        }
+
+        return true;
+    }
+}  // namespace SaveFileState

--- a/src/SaveFileState/SaveFileState.h
+++ b/src/SaveFileState/SaveFileState.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "PresetManager/PresetManager.h"
+
+namespace SaveFileState {
+    constexpr uint32_t CosaveUID = 0xa0B0D9ee;
+    constexpr uint32_t PresetNameIndexMapTypeID = 0xa0B0D9e0;
+
+    // Making a call for each tiny piece of data and having SKSE copy it into its filestream
+    // is the recipe for a mod that makes saves and loads take longer than they should.
+    // We buffer our reads and writes.
+    constexpr size_t BufferSize = 65536;
+    using Buffer = uint8_t[BufferSize];
+
+    void SaveState(SKSE::SerializationInterface* save);
+    void LoadState(SKSE::SerializationInterface* load);
+    void RevertState(SKSE::SerializationInterface* revert);
+
+    bool WriteRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* save, Buffer buffer,
+                                                const PresetManager::PresetContainer& presetContainer);
+    bool ReadRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* load, Buffer buffer,
+                                               PresetManager::PresetContainer& presetContainer);
+
+    struct PresetNameIndexMapHeaderV0 {
+        PresetManager::SparsePresetIndex nextPresetIndex;
+    };
+
+    static_assert(sizeof(PresetNameIndexMapHeaderV0) == 4);
+
+    struct StateForPresetNameV0 {
+        uint32_t presetIndex;
+    };
+
+    static_assert(sizeof(StateForPresetNameV0) == 4);
+
+    using PresetNameLength = uint32_t;
+
+    // Used to round up an integer to a specified multiple-of-power-of-two alignment.
+    template <typename I>
+    inline __forceinline constexpr I AlignUpTo(I value, I alignment) {
+        return static_cast<I>((value + alignment - 1) & ~(alignment - 1));
+    }
+
+    template <typename I>
+    inline __forceinline constexpr bool IsAlignedTo(I value, I alignment) {
+        return (value & (alignment - 1)) == 0;
+    }
+}  // namespace SaveFileState

--- a/src/SaveFileState/SaveFileState.h
+++ b/src/SaveFileState/SaveFileState.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "ActorTracker/ActorTracker.h"
 #include "PresetManager/PresetManager.h"
 
 namespace SaveFileState {
     constexpr uint32_t CosaveUID = 0xa0B0D9ee;
+    constexpr uint32_t ActorRegistryTypeID = 0xa0B0D9ea;
     constexpr uint32_t PresetNameIndexMapTypeID = 0xa0B0D9e0;
 
     // Making a call for each tiny piece of data and having SKSE copy it into its filestream
@@ -15,6 +17,11 @@ namespace SaveFileState {
     void SaveState(SKSE::SerializationInterface* save);
     void LoadState(SKSE::SerializationInterface* load);
     void RevertState(SKSE::SerializationInterface* revert);
+
+    bool WriteRecordDataForActorRegistryV0(SKSE::SerializationInterface* save, Buffer buffer,
+                                           const ActorTracker::Registry& registry);
+    bool ReadRecordDataForActorRegistryV0(SKSE::SerializationInterface* load, Buffer buffer,
+                                          ActorTracker::Registry& registry);
 
     bool WriteRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* save, Buffer buffer,
                                                 const PresetManager::PresetContainer& presetContainer);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -88,6 +88,12 @@ namespace {
 
                 logger::info("Synthesis installed value is {}.", obody.synthesisInstalled);
 
+                logger::info("Becoming ready for plugin-API usage.");
+                if (obody.BecomingReadyForPluginAPIUsage()) {
+                    obody.ReadyForPluginAPIUsage();
+                }
+                logger::info("Now ready for plugin-API usage.");
+
                 return;
             }
 


### PR DESCRIPTION
There's a complementary PR for the Papyrus side of OBody, here: https://github.com/Aietos/OBody/pull/1

---

This PR adds a native plugin-API to OBody, and makes it so that OBody stores preset assignments in its own SKSE cosave, so that native code can know what preset is assigned to an actor.

I'm in no hurry for this to be merged, please review this at your own leisure.

---

This diff isn't quite as big as it looks, at least a thousand-or-so lines are purely GPL licence text and documentation.
I've split the changes into multiple commits, in a hopefully logical order.

The general overview of the changes are:
- A native plugin-API, detailed in `src/API/API.h`.
- Preset assignments are now stored in the SKSE cosave, so that native code can find out what preset is assigned to an actor.
- `boost_unordered` has been introduced as a dependency, for fast and thread-safe hashtables. (The one use of `std::unordered_map` has been replaced with `boost::unordered_flap_map`, for a tiny boost in performance).

The plugin-API provides mod authors with the ability to:
- Query information about OBody.
- Query information about actors.
- Receive events regarding changes to actors.
- Effect changes to actors.

I've tried my best to define the plugin-API such that it's possible to make changes to the API and the ABI without breaking mods that were compiled for older versions of the API—primarily by making mods specify which version of the plugin-API they support.

Additionally, I've tried to make it so that mods that can make changes in response to OBody events, without causing catastrophic bugs like infinite loops that freeze and crash to game; the main mechanism for this is preventing the recursive sending of events, on a per-actor basis.

The plugin-API is thread-safe, insomuch in that multiple threads using the plugin-API simultaneously won't cause memory corruption.


To enable other mods (and OBody) to query which preset is assigned to an actor, OBody now stores the presets assigned to each actor in its SKSE cosave.
So as not to bloat save files, this is achieved by assigning a 20-bit integer to each preset, and pairing each actor's form-ID with 32-bits of state.
To assign a unique and stable integer to each preset, OBody also saves the preset-index assignments to its SKSE cosave.

There is a limitation for querying preset assignments in that existing preset assignments (those stored via StorageUtil by Papyrus) aren't picked up by native code.
As far as I'm aware PapyrusUtil hasn't got an API for native usage, and whilst we could get the Papyrus side of OBody to inform the native side of what the existing preset assignments are—I can't think of a performant nor nice way to do so.
As it stands, only newly made preset assignments will be known by native code.
