### PR TITLE
Add an option for respectful application of morphs

### DIFF
--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -207,7 +207,14 @@ namespace Body {
     void OBody::GenerateBodyByPreset(RE::Actor* a_actor, PresetManager::Preset& a_preset,
                                      const bool updateMorphsWithoutTimer) const {
         // Start by clearing any previous OBody morphs
-        morphInterface->ClearMorphs(a_actor);
+        if (setRespectfulMorphApplication) {
+            morphInterface->ClearBodyMorphKeys(a_actor, "OBody");
+            morphInterface->ClearBodyMorphKeys(a_actor, "OClothe");
+        } else {
+            // For backwards compatibility we clear all morphs instead of just our own,
+            // unless the user has opted-in for us to be more respectful.
+            morphInterface->ClearMorphs(a_actor);
+        }
 
         // Apply the preset's sliders
         ApplySliderSet(a_actor, a_preset.sliders, "OBody");

--- a/src/Body/Body.h
+++ b/src/Body/Body.h
@@ -60,6 +60,7 @@ namespace Body {
         bool setNippleRand = true;
         bool setGenitalRand = true;
         bool setPerformanceMode = true;
+        bool setRespectfulMorphApplication = false;
 
         std::string distributionKey;
 

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -28,6 +28,10 @@ namespace PapyrusBody {
         Body::OBody::GetInstance().setPerformanceMode = a_enabled;
     }
 
+    void SetRespectfulMorphApplication(RE::StaticFunctionTag*, const bool a_enabled) {
+        Body::OBody::GetInstance().setRespectfulMorphApplication = a_enabled;
+    }
+
     // ReSharper disable once CppPassValueParameterByConstReference
     void SetDistributionKey(RE::StaticFunctionTag*,
                             const std::string a_distributionKey) {  // NOLINT(*-unnecessary-value-param)
@@ -125,6 +129,7 @@ namespace PapyrusBody {
         OBODY_PAPYRUS_BIND(SetNippleRand);
         OBODY_PAPYRUS_BIND(SetGenitalRand);
         OBODY_PAPYRUS_BIND(SetPerformanceMode);
+        OBODY_PAPYRUS_BIND(SetRespectfulMorphApplication);
         OBODY_PAPYRUS_BIND(SetDistributionKey);
 #undef OBODY_PAPYRUS_BIND
         return true;

--- a/src/Papyrus/PapyrusBody.h
+++ b/src/Papyrus/PapyrusBody.h
@@ -15,6 +15,8 @@ namespace PapyrusBody {
 
     void SetPerformanceMode(RE::StaticFunctionTag*, bool a_enabled);
 
+    void SetRespectfulMorphApplication(RE::StaticFunctionTag*, bool a_enabled);
+
     void SetDistributionKey(RE::StaticFunctionTag*, std::string a_distributionKey);
 
     int GetFemaleDatabaseSize(RE::StaticFunctionTag*);


### PR DESCRIPTION
This PR has a corresponding PR on the Papryus side: https://github.com/Aietos/OBody/pull/2

---

When generating an actor, OBody clears every morph of an actor, which doesn't play nicely with other mods that apply body morphs.
In an older commit, OBody-morph-only clearing was commented out in the actor generation method, so I assume that all morphs are cleared intentionally, and not as a bug: https://github.com/Aietos/OBody-NG/blob/0db5c64bb25494541829ea21e181798dae719e5c/src/Body/Body.cpp#L349-L351

This adds an option for clearing only OBody's morphs, when generating an actor, for improved compatibility with other morph-altering mods.
