### PR TITLE
Fix the build.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,7 @@ namespace {
         auto log{std::make_shared<spdlog::logger>("Global")};
         auto& log_sinks{log->sinks()};
 
-        if (REX::W32::IsDebuggerPresent()) {
+        if (SKSE::WinAPI::IsDebuggerPresent()) {
             log_sinks.reserve(2);
             const auto msvc_sink{std::make_shared<spdlog::sinks::msvc_sink_mt>()};
             msvc_sink->set_pattern("[%Y-%m-%d %H:%M:%S.%e] [%n] [%l] [OBody.dll,%s:%#] %v");
@@ -199,9 +199,9 @@ namespace {
                 return;
             }
             case SKSE::MessagingInterface::kPostLoad: {
-                const REX::W32::HMODULE tweaks{REX::W32::GetModuleHandleA("po3_Tweaks")};
+                const SKSE::WinAPI::HMODULE tweaks{GetModuleHandle("po3_Tweaks")};
                 stl::func = reinterpret_cast<stl::PO3_tweaks_GetFormEditorID>(
-                    REX::W32::GetProcAddress(tweaks, "GetFormEditorID"));
+                    SKSE::WinAPI::GetProcAddress(tweaks, "GetFormEditorID"));
                 logger::info("Got po3_tweaks api: {}", stl::func != nullptr);
 
                 auto serialization = SKSE::GetSerializationInterface();
@@ -231,7 +231,7 @@ SKSEPluginLoad(const SKSE::LoadInterface* a_skse) {
     const auto* const plugin{SKSE::PluginDeclaration::GetSingleton()};
     logger::info("{} {} is loading...", plugin->GetName(), plugin->GetVersion().string("."));
 
-    SKSE::Init(a_skse, false);
+    SKSE::Init(a_skse);
 
     if (const auto* const message = SKSE::GetMessagingInterface(); !message->RegisterListener(SKSEMessageHandler)) {
         return false;

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,25 +1,16 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "33e9c99208736b713cabe4490e15235f62f893d4",
+    "baseline": "74e6536215718009aae747d86d84b78376bf9e09",
     "repository": "https://github.com/microsoft/vcpkg.git"
   },
   "registries": [
     {
       "kind": "git",
-      "baseline": "c6d868d34b65ebd9119d0a2698bf50a85c7ec7c8",
-      "repository": "https://github.com/ThirdEyeSqueegee/CommonLibSSE-NG-vcpkg",
+      "baseline": "6309841a1ce770409708a67a9ba5c26c537d2937",
+      "repository": "https://gitlab.com/colorglass/vcpkg-colorglass",
       "packages": [
         "commonlibsse-ng"
-      ]
-    },
-    {
-      "kind": "git",
-      "baseline": "6abaa8a737b8e8318ee7597fee5c5d5e639f8ad0",
-      "repository": "https://github.com/ThirdEyeSqueegee/vcpkg-ports",
-      "packages": [
-        "openvr",
-        "spdlog"
       ]
     }
   ]


### PR DESCRIPTION
`CLibNGPluginTemplate` seems to have ceased to exist—preventing OBody from being built. :\\

This PR updates `vcpkg-configuration.json` to not reference any deleted/private repositories.
- `spdlog` and `openvr` are now sourced from vcpkg's ports.
- `commonlibsse-ng` is now sourced from Charmed Baryon's port.
- The baselines have been updated to the latest versions.

Some changes have been made to remove the `CLibNGPluginTemplate`-specific guff, so that the code compiles.
