### PR TITLE
Implement logic for migrating legacy StorageUtil preset-assignments over to our SKSE cosave.

### DIFF
--- a/include/BackwardsCompatibility/BackwardsCompatibility.h
+++ b/include/BackwardsCompatibility/BackwardsCompatibility.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ActorTracker/ActorTracker.h"
+
+namespace BackwardsCompatibility {
+    struct StorageUtilFunctions {
+        RE::BSFixedString (*getStringValue)(RE::StaticFunctionTag* base, RE::TESForm* object, const char* key,
+                                            const char* fallback);
+        uint32_t (*getStringKeyCount)(RE::StaticFunctionTag* base, RE::TESForm* object);
+        RE::BSFixedString (*getNthStringKey)(RE::StaticFunctionTag* base, RE::TESForm* object, uint32_t index);
+    };
+
+    bool FindStorageUtilFunctions(StorageUtilFunctions& functions);
+
+    class State {
+    public:
+        static State& GetInstance();
+        void SetStateUponStartOfNewGame();
+        void FixupAfterLoadingGame();
+        bool MigrateStorageUtilPresetAssignmentsOverToSKSECosave(const StorageUtilFunctions& storageUtil);
+
+        union {
+            uint32_t flags = 0;
+
+            struct {
+                uint32_t haveMigratedStorageUtilPresetAssignments : 1;
+            };
+        };
+
+    private:
+        static State instance;
+    };
+}  // namespace BackwardsCompatibility

--- a/include/Body/Body.h
+++ b/include/Body/Body.h
@@ -119,6 +119,7 @@ namespace Body {
         bool setGenitalRand = true;
         bool setPerformanceMode = true;
         bool setRespectfulMorphApplication = false;
+        bool setLegacyStorageUtilUsageEnabled = true;
 
         std::string distributionKey;
 

--- a/include/Papyrus/PapyrusBody.h
+++ b/include/Papyrus/PapyrusBody.h
@@ -17,6 +17,8 @@ namespace PapyrusBody {
 
     void SetRespectfulMorphApplication(RE::StaticFunctionTag*, bool a_enabled);
 
+    void SetLegacyStorageUtilUsageEnabled(RE::StaticFunctionTag*, bool a_enabled);
+
     void SetDistributionKey(RE::StaticFunctionTag*, std::string a_distributionKey);
 
     int GetFemaleDatabaseSize(RE::StaticFunctionTag*);

--- a/include/SaveFileState/SaveFileState.h
+++ b/include/SaveFileState/SaveFileState.h
@@ -1,12 +1,12 @@
 #pragma once
 
-#include "ActorTracker/ActorTracker.h"
-#include "PresetManager/PresetManager.h"
+#include "BackwardsCompatibility/BackwardsCompatibility.h"
 
 namespace SaveFileState {
     constexpr uint32_t CosaveUID = 0xa0B0D9ee;
     constexpr uint32_t ActorRegistryTypeID = 0xa0B0D9ea;
     constexpr uint32_t PresetNameIndexMapTypeID = 0xa0B0D9e0;
+    constexpr uint32_t BackwardsCompatibilityStateTypeID = 0xa0B0D9bc;
 
     // Making a call for each tiny piece of data and having SKSE copy it into its filestream
     // is the recipe for a mod that makes saves and loads take longer than they should.
@@ -27,6 +27,11 @@ namespace SaveFileState {
                                                 const PresetManager::PresetContainer& presetContainer);
     bool ReadRecordDataForPresetNameIndexMapV0(SKSE::SerializationInterface* load, Buffer buffer,
                                                PresetManager::PresetContainer& presetContainer);
+
+    bool WriteRecordDataForBackwardsCompatibilityStateV0(SKSE::SerializationInterface* save, Buffer buffer,
+                                                         const BackwardsCompatibility::State& backwardsCompatibility);
+    bool ReadRecordDataForBackwardsCompatibilityStateV0(SKSE::SerializationInterface* load, Buffer buffer,
+                                                        BackwardsCompatibility::State& backwardsCompatibility);
 
     struct PresetNameIndexMapHeaderV0 {
         PresetManager::SparsePresetIndex nextPresetIndex;

--- a/src/BackwardsCompatibility/BackwardsCompatibility.cpp
+++ b/src/BackwardsCompatibility/BackwardsCompatibility.cpp
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "BackwardsCompatibility/BackwardsCompatibility.h"
+#include "Body/Body.h"
+
+BackwardsCompatibility::State BackwardsCompatibility::State::instance;
+
+namespace BackwardsCompatibility {
+    State& State::GetInstance() { return instance; }
+
+    void State::SetStateUponStartOfNewGame() { haveMigratedStorageUtilPresetAssignments = true; }
+
+    void State::FixupAfterLoadingGame() {
+        if (!haveMigratedStorageUtilPresetAssignments) {
+            StorageUtilFunctions storageUtil;
+            if (FindStorageUtilFunctions(storageUtil)) {
+                if (MigrateStorageUtilPresetAssignmentsOverToSKSECosave(storageUtil)) {
+                    haveMigratedStorageUtilPresetAssignments = true;
+                }
+            }
+        }
+    }
+
+    bool State::MigrateStorageUtilPresetAssignmentsOverToSKSECosave(const StorageUtilFunctions& storageUtil) {
+        logger::info("Migrating legacy StorageUtil preset assignments over to the SKSE cosave.");
+
+        uint32_t stringKeyCount = storageUtil.getStringKeyCount(nullptr, nullptr);
+        logger::info("StorageUtil.stringKeyCount: {}", stringKeyCount);
+
+        if (stringKeyCount == 0) {
+            logger::info("There were no legacy StorageUtil preset assignments to migrate!");
+            return true;
+        }
+
+        auto& presets{PresetManager::PresetContainer::GetInstance()};
+        auto& registry{ActorTracker::Registry::GetInstance()};
+
+        for (uint32_t index = 0; index < stringKeyCount; ++index) {
+            RE::BSFixedString fixedKey = storageUtil.getNthStringKey(nullptr, nullptr, index);
+
+            // We're looking for keys in this format: `obody_<int32 as decimal>_preset`.
+
+            auto keyLength = fixedKey.length();
+            if (keyLength < 14) continue;
+            const char* key = fixedKey.data();
+            if ("obody_"sv.compare({key, 6}) != 0) continue;
+            const char* endOfFormID = key + keyLength - 7;
+            if ("_preset"sv.compare({endOfFormID, 7}) != 0) continue;
+
+            int32_t formID;
+            auto parse = std::from_chars(key + 6, endOfFormID, formID);
+            if ((parse.ec != std::errc()) | (parse.ptr != endOfFormID)) continue;
+
+            RE::BSFixedString fixedValue = storageUtil.getStringValue(nullptr, nullptr, key, nullptr);
+
+            const char* value = fixedValue.data();
+            auto valueLength = fixedValue.length();
+
+            if (value == nullptr) {
+                logger::info("StorageUtil preset assignment: {:#010x} = <null>", (uint32_t)formID);
+                continue;
+            }
+
+            logger::info("StorageUtil preset assignment: {:#010x} = {}", (uint32_t)formID,
+                         std::string_view{value, valueLength});
+
+            RE::Actor* actor = RE::TESForm::LookupByID<RE::Actor>(formID);
+
+            if (actor == nullptr) {
+                logger::info("\tNo actor could be found with a form-ID of {:#010x}", (uint32_t)formID);
+                continue;
+            }
+
+            bool isFemale = Body::OBody::IsFemale(actor);
+
+            std::string presetName{value, valueLength};
+
+            auto& presetIndexMap = isFemale ? presets.femalePresetIndexByName : presets.malePresetIndexByName;
+            auto& nextPresetIndex = isFemale ? presets.nextFemalePresetIndex : presets.nextMalePresetIndex;
+
+            auto indexAssignment = presetIndexMap.emplace(presetName, nextPresetIndex.value);
+
+            if (indexAssignment.second) {
+                // This is a preset name we haven't seen before.
+                ++nextPresetIndex.value;
+                // The sparse-index is mapped to -1 because the preset is absent.
+                (isFemale ? presets.allFemalePresetsByIndex : presets.allMalePresetsByIndex)
+                    .resize(nextPresetIndex.value, (PresetManager::SparsePresetIndex)-1);
+
+                // Maybe the actor's sex has changed since the preset was assigned?
+                auto& presetIndexMapOtherSex =
+                    isFemale ? presets.malePresetIndexByName : presets.femalePresetIndexByName;
+                auto& nextPresetIndexOtherSex = isFemale ? presets.nextMalePresetIndex : presets.nextFemalePresetIndex;
+                auto indexAssignmentOtherSex =
+                    presetIndexMapOtherSex.emplace(presetName, nextPresetIndexOtherSex.value);
+
+                if (indexAssignmentOtherSex.second) {
+                    // This is also a preset name we haven't seen before.
+                    ++nextPresetIndexOtherSex.value;
+                    // The sparse-index is mapped to -1 because the preset is absent.
+                    (isFemale ? presets.allMalePresetsByIndex : presets.allFemalePresetsByIndex)
+                        .resize(nextPresetIndexOtherSex.value, (PresetManager::SparsePresetIndex)-1);
+                }
+            }
+
+            auto assignedIndex = indexAssignment.first->second;
+
+            ActorTracker::ActorState actorState{};
+            // Plus one because an index of zero on the actor signifies the absence of a preset.
+            actorState.presetIndex = assignedIndex.value + 1;
+
+            // If the actor already has an entry in the actor-tracker we'll not overwrite it.
+            // The SKSE cosave assignments take precedence over the StorageUtil assignments.
+            if (registry.stateForActor.emplace(formID, actorState)) {
+                logger::info("\tAssigned a preset-index of {}", assignedIndex.value);
+            } else {
+                logger::info("\tDid not assign a preset-index of {}, for the actor already has a preset-assignment.",
+                             assignedIndex.value);
+            }
+        }
+
+        logger::info("Migrated legacy StorageUtil preset assignments over to the SKSE cosave!");
+        return true;
+    }
+
+    bool FindStorageUtilFunctions(StorageUtilFunctions& functions) {
+        auto papyrus = RE::BSScript::Internal::VirtualMachine::GetSingleton();
+
+        if (papyrus == nullptr) {
+            return false;
+        }
+
+        RE::BSTSmartPointer<RE::BSScript::ObjectTypeInfo> storageUtilTypeInfo{};
+        if (!papyrus->GetScriptObjectType1("StorageUtil", storageUtilTypeInfo)) {
+            return false;
+        }
+
+        uint32_t globalFunctionCount = storageUtilTypeInfo->GetNumGlobalFuncs();
+
+        if (globalFunctionCount < 3) {
+            return false;
+        }
+
+        const RE::BSScript::ObjectTypeInfo::GlobalFuncInfo* globalFunctions = storageUtilTypeInfo->GetGlobalFuncIter();
+        const RE::BSScript::ObjectTypeInfo::GlobalFuncInfo* globalFunctionsEnd = globalFunctions + globalFunctionCount;
+
+        uint32_t found = 0;
+
+        for (auto globalFunction = globalFunctions; globalFunction < globalFunctionsEnd; ++globalFunction) {
+            if (found == 0b111) {
+                return true;
+            }
+
+            const RE::BSTSmartPointer<RE::BSScript::IFunction>& function = globalFunction->func;
+
+            if (!function->GetIsNative()) {
+                continue;
+            }
+
+            const RE::BSFixedString& fixedName = function->GetName();
+            auto nameLength = fixedName.length();
+
+            if (nameLength < 14) {
+                continue;
+            }
+
+            const std::string_view name = {fixedName.data(), nameLength};
+
+            static_assert(sizeof(RE::BSScript::NF_util::NativeFunctionBase) == 0x50);
+
+            // This member is protected, so we can't access it nicely,
+            // but its offset is the same across every versions of Skyrim SE>
+            uintptr_t callback = reinterpret_cast<uintptr_t>(function.get()) + 0x50;
+
+            if ("GetStringValue"sv.compare(name) == 0) {
+                functions.getStringValue =
+                    *reinterpret_cast<const decltype(StorageUtilFunctions::getStringValue)*>(callback);
+                logger::info("Found StorageUtil::GetStringValue: {:#018x}", callback);
+                found |= 1 << 0;
+            } else if ("debug_GetStringKeysCount"sv.compare(name) == 0) {
+                functions.getStringKeyCount =
+                    *reinterpret_cast<const decltype(StorageUtilFunctions::getStringKeyCount)*>(callback);
+                logger::info("Found StorageUtil::debug_GetStringKeysCount: {:#018x}", callback);
+                found |= 1 << 1;
+            } else if ("debug_GetStringKey"sv.compare(name) == 0) {
+                functions.getNthStringKey =
+                    *reinterpret_cast<const decltype(StorageUtilFunctions::getNthStringKey)*>(callback);
+                logger::info("Found StorageUtil::debug_GetStringKey: {:#018x}", callback);
+                found |= 1 << 2;
+            }
+        }
+
+        return found == 0b111;
+    }
+}  // namespace BackwardsCompatibility

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -35,6 +35,10 @@ namespace PapyrusBody {
         Body::OBody::GetInstance().setRespectfulMorphApplication = a_enabled;
     }
 
+    void SetLegacyStorageUtilUsageEnabled(RE::StaticFunctionTag*, const bool a_enabled) {
+        Body::OBody::GetInstance().setLegacyStorageUtilUsageEnabled = a_enabled;
+    }
+
     // ReSharper disable once CppPassValueParameterByConstReference
     void SetDistributionKey(RE::StaticFunctionTag*,
                             const std::string a_distributionKey) {  // NOLINT(*-unnecessary-value-param)
@@ -267,6 +271,7 @@ namespace PapyrusBody {
         OBODY_PAPYRUS_BIND(SetGenitalRand);
         OBODY_PAPYRUS_BIND(SetPerformanceMode);
         OBODY_PAPYRUS_BIND(SetRespectfulMorphApplication);
+        OBODY_PAPYRUS_BIND(SetLegacyStorageUtilUsageEnabled);
         OBODY_PAPYRUS_BIND(SetDistributionKey);
 #undef OBODY_PAPYRUS_BIND
         return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "BackwardsCompatibility/BackwardsCompatibility.h"
 #include "Body/Body.h"
 #include "Body/Event.h"
 #include "Papyrus/Papyrus.h"
@@ -160,6 +161,8 @@ namespace {
             case SKSE::MessagingInterface::kNewGame: {
                 logger::info("New Game started");
 
+                BackwardsCompatibility::State::GetInstance().SetStateUponStartOfNewGame();
+
                 PresetManager::PresetContainer::GetInstance().AssignPresetIndexes();
 
                 Event::OBodyEventHandler::Register();
@@ -191,6 +194,8 @@ namespace {
 
                 // Now that our cosave has loaded, we can assign indexes to the presets that we loaded earlier.
                 PresetManager::PresetContainer::GetInstance().AssignPresetIndexes();
+
+                BackwardsCompatibility::State::GetInstance().FixupAfterLoadingGame();
 
                 Event::OBodyEventHandler::Register();
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -53,9 +53,11 @@ target("OBody")
         author = "Aietos"
     })
 
-    -- add MSVC preprocessor flag for __VA_OPT__ support
     if is_plat("windows") then
+        -- add MSVC preprocessor flag for __VA_OPT__ support
         add_cxflags("cl::/Zc:preprocessor")
+        -- Anonymous aggregate types are _fine_.
+        add_cxflags("cl::/wd4201")
     end
 
     -- add src files


### PR DESCRIPTION
There's a complementary PR for the Papyrus side of OBody, here: Aietos/OBody#3.

---

To summarise the present state of things: https://github.com/Aietos/OBody-NG/pull/6 made it so that preset-assignments are stored in the SKSE cosave, such that native code can efficiently query them. \
However, pre-existing StorageUtil-saved preset-assignments are not accessible from native code, because I couldn't think of a way to do so.

This means that in order for mods that use OBody's API to work properly always, users have to do one of:
- Start a new game (blegh).
- Reset the OBody distribution key (ugh).
- Manually reassign the preset for every NPC with an already assigned-preset (eh).

This is frankly a bit shit, and I'm not terribly pleased about it.

So, I took another look and it turns out that StorageUtil does define some functions for iterating its stored keys. \
And, whilst it doesn't expose an API for native code... there's nothing stopping us from reaching into the Papyrus VM for a few function-pointers 😈.

---

This PR does two distinct things:
1. It implements logic for migrating legacy StorageUtil preset-assignments over to our SKSE cosave, which runs only once for saves that may need it.
2. It makes the storing of preset-assignments via StorageUtil an option, so that users can disable it to slightly reduce OBody's contribution to save-file sizes. \
It's enabled by default because there are mods that rely on those values. (Such as [OBody HotSwap (NSFW)](https://www.nexusmods.com/skyrimspecialedition/mods/127986)).

This also means we can rid ourselves of the `ObodyNative.GetPresetAssignedToActor` vs `ObodyNative.GetPresetAssignedToActorExhaustively` split on the Papyrus-side, and instead have just `ObodyNative.GetPresetAssignedToActor`.

