### PR TITLE
Account for changes in load-order when loading preset-assignments.

### DIFF
--- a/src/SaveFileState/SaveFileState.cpp
+++ b/src/SaveFileState/SaveFileState.cpp
@@ -217,9 +217,10 @@ namespace SaveFileState {
             offset += sizeof(decltype(actorState));
             remainingBytes -= sizeof(decltype(actorState));
 
-            actorState.value = actorState.value & ActorTracker::ActorState::PersistedInCosaveMask;
-
-            registry.stateForActor.insert_or_assign(formID, actorState);
+            if (load->ResolveFormID(formID, formID)) {
+                actorState.value = actorState.value & ActorTracker::ActorState::PersistedInCosaveMask;
+                registry.stateForActor.insert_or_assign(formID, actorState);
+            }
         }
 
         assert(false);


### PR DESCRIPTION
I'm so glad I remembered this existed. \
This would have been a few-hundred lines and a few-dozen kilobytes of save-bloat otherwise.

If the user changes their load-order, such that the form-ID of an NPC changes, the preset-assignment for that NPC will no longer be lost (or apply to a different mod's NPC!).