### PR TITLE
Use the correct form-ID when clearing the preset-assignment for a blacklisted NPC.

### DIFF
--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -189,7 +189,7 @@ namespace Body {
             // Clear their preset assignment, if they have one.
             auto& registry{ActorTracker::Registry::GetInstance()};
             uint32_t previousPresetIndex = 0;
-            registry.stateForActor.visit(actorID, [&](auto& entry) {
+            registry.stateForActor.visit(a_actor->formID, [&](auto& entry) {
                 previousPresetIndex = entry.second.presetIndex;
                 entry.second.presetIndex = 0;
             });


### PR DESCRIPTION
A simple bug-fix; we should be using the actor's ID instead of the actor-base's ID here.