### PR TITLE
Fix a potential crash in `MigrateStorageUtilPresetAssignmentsOverToSKSECosave`.

### DIFF
--- a/cmakelists.txt
+++ b/cmakelists.txt
@@ -5,7 +5,7 @@
 # project
 cmake_minimum_required(VERSION 3.15.0)
 cmake_policy(SET CMP0091 NEW)
-project(OBody VERSION 4.4.3 LANGUAGES CXX)
+project(OBody VERSION 4.4.4 LANGUAGES CXX)
 set(CURRENT_COMPILER_ID ${CMAKE_CXX_COMPILER_ID})
 
 # target

--- a/src/BackwardsCompatibility/BackwardsCompatibility.cpp
+++ b/src/BackwardsCompatibility/BackwardsCompatibility.cpp
@@ -71,7 +71,21 @@ namespace BackwardsCompatibility {
                 continue;
             }
 
-            bool isFemale = Body::OBody::IsFemale(actor);
+            const RE::TESNPC* actorBase = actor->GetActorBase();
+
+            if (actorBase == nullptr) {
+                logger::info("\tAn actor could be found with a form-ID of {:#010x}, but it has no actor-base.", (uint32_t)formID);
+
+                // Maybe the NPC template can act as substitute?
+                actorBase = actor->GetTemplateBase();
+
+                if (actorBase == nullptr) {
+                    logger::info("\t\tIt also has no template-base, so the actor is being ignored.");
+                    continue;
+                }
+            }
+
+            bool isFemale = actorBase->IsFemale();
 
             std::string presetName{value, valueLength};
 

--- a/xmake.lua
+++ b/xmake.lua
@@ -6,7 +6,7 @@ includes ("lib/commonlibsse-ng")
 
 -- set project
 set_project("OBody")
-set_version("4.4.3")
+set_version("4.4.4")
 set_license("GPL-3.0")
 
 -- set defaults


### PR DESCRIPTION
[Some users have been reporting a crash when loading pre-existing save games with OBody 4.4.x](https://www.nexusmods.com/skyrimspecialedition/mods/77016?tab=posts#comment-161180740).

It turns out `Actor`s can lack an `ActorBase`—who knew?

I'm assuming that this is the backwards-compatibility code coming across an actor that might not really exist properly anymore, or external form-ID reordering, that the StorageUtil storage method couldn't account for, causing oddities. \
Either way, I don't think `OBody::IsFemale` needs to account for the possibility of null `ActorBase`s, so I've left it unchanged.
