### PR TITLE
feat: added customizable refit preset support

### DIFF
--- a/include/ActorTracker/ActorTracker.h
+++ b/include/ActorTracker/ActorTracker.h
@@ -36,6 +36,10 @@ namespace ActorTracker {
     public:
         static Registry& GetInstance();
 
+        uint32_t GetPresetIndexForActor(RE::Actor* a_actor) const;
+        std::optional<PresetManager::Preset> GetPresetForActor(RE::Actor* a_actor, const bool isFemale) const;
+        std::optional<std::string> GetPresetNameForActor(RE::Actor* a_actor, const bool isFemale) const;
+
         boost::concurrent_flat_map<RE::FormID, ActorState> stateForActor;
 
     private:

--- a/include/JSONParser/JSONParser.h
+++ b/include/JSONParser/JSONParser.h
@@ -57,6 +57,8 @@ namespace Parser {
         std::vector<categorizedList> blacklistedOutfitCategorySet;
         std::vector<categorizedList> forceRefitOutfitCategorySet;
 
+        std::optional<PresetManager::Preset> GetRefitPresetFromEquippedItems(RE::Actor* a_actor, bool female);
+
     private:
         JSONParser() = default;
         static JSONParser instance;

--- a/json schema/OBody_presetDistributionConfig_schema.json
+++ b/json schema/OBody_presetDistributionConfig_schema.json
@@ -63,6 +63,12 @@
     },
     "blacklistedPresetsShowInOBodyMenu": {
       "$ref": "#/definitions/blacklistedPresetsShowInOBodyMenu"
+    },
+    "refitOutfitPresetsFemale": {
+      "$ref": "#/definitions/refitOutfitPresets"
+    },
+    "refitOutfitPresetsMale": {
+      "$ref": "#/definitions/refitOutfitPresets"
     }
   },
   "title": "OBodyConfigModel",
@@ -344,6 +350,17 @@
       "description": "Same as above, but for males. ONLY put male body presets here (if you don't have any, leave it empty)!",
       "propertyNames": {
         "$ref": "#/definitions/RaceName"
+      },
+      "type": "object"
+    },
+    "refitOutfitPresets": {
+      "additionalProperties": {
+        "type": "string"
+      },
+      "default": {},
+      "description": "Here you can write outfit name and preset name pairs to enforce a specific ORefit preset for a specific outfits.",
+      "propertyNames": {
+        "$ref": "#/definitions/OutfitName"
       },
       "type": "object"
     }

--- a/json schema/python/OBodyConfigModel.py
+++ b/json schema/python/OBodyConfigModel.py
@@ -66,6 +66,10 @@ type outfitsForceRefit = Annotated[List[OutfitName], Field(default=[],
 type blacklistedPresetsShowInOBodyMenu = Annotated[
     bool, Field(default=True, description="Whether you want the blacklisted presets to show in the O menu or not.")]
 
+type refitOutfitPresetsFemale = Annotated[Dict[OutfitName, PresetName], Field(default={}, description="Here you can write outfit name and preset name pairs to enforce a specific ORefit preset for a specific outfits.")]
+
+type refitOutfitPresetsMale = Annotated[Dict[OutfitName, PresetName], Field(default={}, description="Here you can write outfit name and preset name pairs to enforce a specific ORefit preset for a specific outfits.")]
+
 
 class OBodyConfigModel(BaseModel):
     model_config = ConfigDict(extra='forbid', strict=True, regex_engine='python-re', populate_by_name=True)
@@ -91,13 +95,15 @@ class OBodyConfigModel(BaseModel):
     outfitsForceRefit: outfitsForceRefit
     blacklistedPresetsFromRandomDistribution: blacklistedPresetsFromRandomDistribution
     blacklistedPresetsShowInOBodyMenu: blacklistedPresetsShowInOBodyMenu
+    refitOutfitPresetsFemale: refitOutfitPresetsFemale
+    refitOutfitPresetsMale: refitOutfitPresetsMale
 
 
 def main(using_rapidjson: bool):
     # src: https://www.nexusmods.com/skyrimspecialedition/articles/4756
     test_examples: list[str] = [
         """{"npcFormID":{"Skyrim.esm":{"00013BA3":["Bardmaid"],"00013BA2":["Wench Preset","IA - Demonic","Tasty Temptress - BHUNP Preset (Nude)"]},"Immersive Wenches.esp":{"0403197F":["Petite Mommy"],"0400C3C0":["s4rMs' - Gaia"]}},"npc":{"Mjoll the Lioness":["Hardass Warrior"],"Haelga":["Petite Mommy","IA - Demonic","s4rMs' - Gaia"],"Temba Wide-Arm":["Tasty Temptress - BHUNP Preset (Nude)"]},"factionFemale":{"SolitudeBardsCollegeFaction":["Hardass Warrior","Fantasy Figure - Nude","Royal Battle Maiden - BHUNP"],"TownSolitudeFaction":["QC-The Everywoman"],"CollegeofWinterholdFaction":["Tasty Temptress - BHUNP Preset (Nude)"]},"factionMale":{"CompanionsCircle":["HIMBO Muscled"],"TownWhiterunFaction":["HIMBO Simple"]},"npcPluginFemale":{"Bijin_AIO_Merged.esp":["Hardass warrior","SilverR1baka"],"Skyrim.esm":["Nordic Oppai - BHUNP - Nude"]},"npcPluginMale":{"Dawnguard.esm":["HIMBO Simple"]},"raceFemale":{"NordRace":["QC-The Everywoman","D*sney Mommy NG","Fantasy Figure - Nude"],"OrcRace":["Hardass warrior"],"WoodElfRace":["-Zeroed Sliders-"]},"raceMale":{"NordRace":["HIMBO Simple"],"BretonRace":["HIMBO Simple"]},"blacklistedNpcs":["Saffir","Vilja","Lydia"],"blacklistedNpcsFormID":{"Skyrim.esm":["00013BB8","00013BBD"],"CS_Vayne.esp":["0400083D","0402CC59"]},"blacklistedNpcsPluginFemale":["CS_Coralyn.esp","3DNPC.esp","Hearthfires.esm"],"blacklistedNpcsPluginMale":["Immersive Wenches.esp","018Auri.esp"],"blacklistedRacesFemale":["ElderRace","ArgonianRace"],"blacklistedRacesMale":["ElderRace","DarkElfRace"],"blacklistedOutfitsFromORefitFormID":{"[full_inu] Queen Marika's Dress.esp":["FE000817"]},"blacklistedOutfitsFromORefit":["Demon Hunter's Clothes Light","White Sexy Top Ouvert","Wrap Around Dress (Slutty) - 14"],"blacklistedOutfitsFromORefitPlugin":["[COCO] Mysterious Mage.esp"],"outfitsForceRefitFormID":{"[full_inu] Queen Marika's Dress.esp":["FE000803"]},"outfitsForceRefit":["Demon Hunter's Lingerie Light","Demon Hunter's Lingerie Heavy"],"blacklistedPresetsFromRandomDistribution":["- Zeroed Sliders -","-Zeroed Sliders-","Zeroed Sliders","s4mRs'' - Juno","Royal Battlemaiden - BHUNP"],"blacklistedPresetsShowInOBodyMenu":true}""",
-        """{"npcFormID":{},"npc":{},"factionFemale":{},"factionMale":{},"npcPluginFemale":{},"npcPluginMale":{},"raceFemale":{},"raceMale":{},"blacklistedNpcs":[],"blacklistedNpcsFormID":{},"blacklistedNpcsPluginFemale":[],"blacklistedNpcsPluginMale":[],"blacklistedRacesFemale":["ElderRace"],"blacklistedRacesMale":["ElderRace"],"blacklistedOutfitsFromORefitFormID":{},"blacklistedOutfitsFromORefit":["LS Force Naked","OBody Nude 32"],"blacklistedOutfitsFromORefitPlugin":[],"outfitsForceRefitFormID":{},"outfitsForceRefit":[],"blacklistedPresetsFromRandomDistribution":["- Zeroed Sliders -","-Zeroed Sliders-","Zeroed Sliders","HIMBO Zero for OBody"],"blacklistedPresetsShowInOBodyMenu":true}""",
+        """{"npcFormID":{},"npc":{},"factionFemale":{},"factionMale":{},"npcPluginFemale":{},"npcPluginMale":{},"raceFemale":{},"raceMale":{},"blacklistedNpcs":[],"blacklistedNpcsFormID":{},"blacklistedNpcsPluginFemale":[],"blacklistedNpcsPluginMale":[],"blacklistedRacesFemale":["ElderRace"],"blacklistedRacesMale":["ElderRace"],"blacklistedOutfitsFromORefitFormID":{},"blacklistedOutfitsFromORefit":["LS Force Naked","OBody Nude 32"],"blacklistedOutfitsFromORefitPlugin":[],"outfitsForceRefitFormID":{},"outfitsForceRefit":[],"blacklistedPresetsFromRandomDistribution":["- Zeroed Sliders -","-Zeroed Sliders-","Zeroed Sliders","HIMBO Zero for OBody"],"blacklistedPresetsShowInOBodyMenu":true,"refitOutfitPresetsFemale":{},"refitOutfitPresetsFemale":{}}""",
     ]
     base_dir = Path(__file__).parent.parent.resolve()
     try:

--- a/src/API/PluginInterface.cpp
+++ b/src/API/PluginInterface.cpp
@@ -122,11 +122,7 @@ namespace OBody::API {
 
         payload.flags = flags;
 
-        auto& registry{ActorTracker::Registry::GetInstance()};
-        auto formID = a_actor->formID;
-        uint32_t actorPresetIndex = 0;
-
-        registry.stateForActor.cvisit(formID, [&](auto& entry) { actorPresetIndex = entry.second.presetIndex; });
+        uint32_t actorPresetIndex = ActorTracker::Registry::GetInstance().GetPresetIndexForActor(a_actor);
 
         if (actorPresetIndex != 0) {
             // Minus one because an index of zero assigned to the actor signifies the absence of a preset.

--- a/src/ActorTracker/ActorTracker.cpp
+++ b/src/ActorTracker/ActorTracker.cpp
@@ -6,4 +6,34 @@ ActorTracker::Registry ActorTracker::Registry::instance;
 
 namespace ActorTracker {
     Registry& Registry::GetInstance() { return instance; }
+
+    uint32_t Registry::GetPresetIndexForActor(RE::Actor* a_actor) const {
+        uint32_t actorPresetIndex = 0;
+        stateForActor.cvisit(a_actor->formID, [&](auto& entry) { actorPresetIndex = entry.second.presetIndex; });
+        return actorPresetIndex;
+    }
+
+    std::optional<PresetManager::Preset> Registry::GetPresetForActor(RE::Actor* a_actor, const bool isFemale) const {
+        uint32_t actorPresetIndex = GetPresetIndexForActor(a_actor);
+
+        if (actorPresetIndex != 0) {
+            // Minus one because an index of zero assigned to the actor signifies the absence of a preset.
+            auto preset = PresetManager::AssignedPresetIndex{actorPresetIndex - 1}.GetPreset(isFemale);
+
+            if (preset) {
+                return *preset;
+            }
+        }
+
+        return std::nullopt;
+    }
+
+    std::optional<std::string> Registry::GetPresetNameForActor(RE::Actor* a_actor, const bool isFemale) const {
+        const auto preset = GetPresetForActor(a_actor, isFemale);
+        if (preset) {
+            return preset->name;
+        }
+        return std::nullopt;
+    }
+
 }  // namespace ActorTracker

--- a/src/Body/Body.cpp
+++ b/src/Body/Body.cpp
@@ -381,6 +381,14 @@ namespace Body {
 
         std::optional<Preset> a_preset = std::nullopt;
 
+        auto& jsonParser{Parser::JSONParser::GetInstance()};
+        a_preset = jsonParser.GetRefitPresetFromEquippedItems(a_actor, isFemale);
+
+        if (a_preset) {
+            ApplySliderSet(a_actor, a_preset->sliders, "OClothe");
+            return;
+        }
+
         const auto a_presetName = ActorTracker::Registry::GetInstance().GetPresetNameForActor(a_actor, isFemale);
         if (a_presetName) {
             const std::string refitPresetName = *a_presetName + "-Refit";

--- a/src/JSONParser/JSONParser.cpp
+++ b/src/JSONParser/JSONParser.cpp
@@ -723,4 +723,49 @@ namespace Parser {
 
         return std::nullopt;
     }
+
+    std::optional<PresetManager::Preset> JSONParser::GetRefitPresetFromEquippedItems(RE::Actor* a_actor, bool female) {
+        const auto refitOutfitPresetsNode {
+            presetDistributionConfig.FindMember(female ? "refitOutfitPresetsFemale" : "refitOutfitPresetsMale")
+        };
+
+        if (refitOutfitPresetsNode == presetDistributionConfig.MemberEnd()) {
+            return std::nullopt;
+        }
+
+        const auto& refitOutfitPresetsObject = refitOutfitPresetsNode->value;
+
+        if (refitOutfitPresetsObject.MemberCount() == 0) {
+            return std::nullopt;
+        }
+
+        const auto& presetContainer{PresetManager::PresetContainer::GetInstance()};
+
+        const RE::BGSBipedObjectForm::BipedObjectSlot slots[3] = {
+            RE::BGSBipedObjectForm::BipedObjectSlot::kBody,
+            RE::BGSBipedObjectForm::BipedObjectSlot::kModChestPrimary,
+            RE::BGSBipedObjectForm::BipedObjectSlot::kModChestSecondary
+        };
+
+        for (RE::BGSBipedObjectForm::BipedObjectSlot slot : slots) {
+            auto outfit{a_actor->GetWornArmor(slot)};
+            if (outfit) {
+                const auto refitOneOutfitPresetNode = refitOutfitPresetsObject.FindMember(outfit->GetName());
+                if (refitOneOutfitPresetNode == refitOutfitPresetsObject.MemberEnd()) {
+                    continue;
+                }
+
+                const auto presetName{refitOneOutfitPresetNode->value.GetString()};
+
+                const auto preset{PresetManager::GetPresetByNameForRandom(female ? presetContainer.allFemalePresets : presetContainer.allMalePresets, presetName)};
+
+                if(preset) {
+                    return preset;
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+
 }  // namespace Parser

--- a/src/Papyrus/PapyrusBody.cpp
+++ b/src/Papyrus/PapyrusBody.cpp
@@ -130,20 +130,9 @@ namespace PapyrusBody {
     }
 
     std::string GetPresetAssignedToActor(RE::StaticFunctionTag*, RE::Actor* a_actor) {
-        auto& registry{ActorTracker::Registry::GetInstance()};
-        auto formID = a_actor->formID;
-        uint32_t actorPresetIndex = 0;
-
-        registry.stateForActor.cvisit(formID, [&](auto& entry) { actorPresetIndex = entry.second.presetIndex; });
-
-        if (actorPresetIndex != 0) {
-            // Minus one because an index of zero assigned to the actor signifies the absence of a preset.
-            auto preset =
-                PresetManager::AssignedPresetIndex{actorPresetIndex - 1}.GetPreset(Body::OBody::IsFemale(a_actor));
-
-            if (preset != nullptr) {
-                return preset->name;
-            }
+        const auto a_presetName = ActorTracker::Registry::GetInstance().GetPresetNameForActor(a_actor, Body::OBody::IsFemale(a_actor));
+        if(a_presetName) {
+            return *a_presetName;
         }
 
         return "";

--- a/src/PresetManager/PresetManager.cpp
+++ b/src/PresetManager/PresetManager.cpp
@@ -54,14 +54,14 @@ namespace PresetManager {
 
                 if (IsFemalePreset(*preset)) {
                     if (std::find(blacklistedPresetsBegin, blacklistedPresetsEnd, preset.value().name.c_str()) !=
-                        blacklistedPresetsEnd) {
+                        blacklistedPresetsEnd || preset.value().name.ends_with("-Refit")) {
                         blacklistedFemalePresets.push_back(*preset);
                     } else {
                         femalePresets.push_back(*preset);
                     }
                 } else {
                     if (std::find(blacklistedPresetsBegin, blacklistedPresetsEnd, preset.value().name.c_str()) !=
-                        blacklistedPresetsEnd) {
+                        blacklistedPresetsEnd || preset.value().name.ends_with("-Refit")) {
                         blacklistedMalePresets.push_back(*preset);
                     } else {
                         malePresets.push_back(*preset);


### PR DESCRIPTION
How to use:

It is now possible to create a global override of the baked in refit preset. To do that simply have a preset named either "Female-Refit" for female actors or "Male-Refit" for male actors. If not having such a preset in the preset list OBody will fall back to the baked in one.

It is also possible to create refit presets for each normal presets. Say you have a preset called "MyPreset". Now if you have another preset called "MyPreset-Refit" each character that has "MyPreset" as selected body will use "MyPreset-Refit" while clothed.

It is very important that refit presets must only contain the differences from the normal base preset. Say that "MyPreset" has value 10 for the Pushup slider. If your desired value for the Pushup slider is 50 then "MyPreset-Refit" must contain value 40 (50-10) for the Pushup slider.

Refit presets (having a suffix "-Refit" in their names) are blacklisted by default meaning they won't be included in random body distribution or appear in the OBody preset selection menu. They are solely used for the refit feature.